### PR TITLE
fix: custom networks reset with mainnet on signin

### DIFF
--- a/src/modals/custom-network-create/custom-network-create.ts
+++ b/src/modals/custom-network-create/custom-network-create.ts
@@ -47,6 +47,7 @@ export class CustomNetworkCreateModal {
         this.network.activePeer = new Peer();
         this.network.activePeer.ip = seedServerUrl.hostname;
         this.network.activePeer.port = Number(seedServerUrl.port);
+        this.network.type = 10
         this.dismiss(this.network);
       }, () => this.configureError());
   }

--- a/src/modals/custom-network-create/custom-network-create.ts
+++ b/src/modals/custom-network-create/custom-network-create.ts
@@ -47,7 +47,7 @@ export class CustomNetworkCreateModal {
         this.network.activePeer = new Peer();
         this.network.activePeer.ip = seedServerUrl.hostname;
         this.network.activePeer.port = Number(seedServerUrl.port);
-        this.network.type = 10
+        this.network.type = 10;
         this.dismiss(this.network);
       }, () => this.configureError());
   }

--- a/src/modals/custom-network-create/custom-network-create.ts
+++ b/src/modals/custom-network-create/custom-network-create.ts
@@ -47,7 +47,7 @@ export class CustomNetworkCreateModal {
         this.network.activePeer = new Peer();
         this.network.activePeer.ip = seedServerUrl.hostname;
         this.network.activePeer.port = Number(seedServerUrl.port);
-        this.network.type = 10;
+        this.network.type = null;
         this.dismiss(this.network);
       }, () => this.configureError());
   }

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -43,7 +43,7 @@ export class ArkApiProvider {
 
       if (lodash.isEmpty(network)) { return; }
 
-      this.setNetwork(network)
+      this.setNetwork(network);
     });
   }
 

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -70,7 +70,7 @@ export class ArkApiProvider {
   public setNetwork(network: StoredNetwork) {
     // set default peer
     const activePeer = network.activePeer;
-    if (network.type !== 10) {
+    if (network.type !== null) {
       const apiNetwork = arkts.Network.getDefault(network.type);
       if (apiNetwork) {
         network = Object.assign<StoredNetwork, arkts.Network>(network, apiNetwork);

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -43,19 +43,7 @@ export class ArkApiProvider {
 
       if (lodash.isEmpty(network)) { return; }
 
-      // set default peer
-      const activePeer = network.activePeer;
-      const apiNetwork = arkts.Network.getDefault(network.type);
-      network = Object.assign<StoredNetwork, arkts.Network>(network, apiNetwork);
-      if (activePeer) {
-        network.activePeer = activePeer;
-      }
-
-      this._network = network;
-      this.arkjs.crypto.setNetworkVersion(this._network.version);
-
-      this._api = new arkts.Client(this._network);
-      this.findGoodPeer();
+      this.setNetwork(network)
     });
   }
 
@@ -77,6 +65,26 @@ export class ArkApiProvider {
     if (!lodash.isEmpty(this._delegates)) { return Observable.of(this._delegates); }
 
     return this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES * 2);
+  }
+
+  public setNetwork(network: StoredNetwork) {
+    // set default peer
+    const activePeer = network.activePeer;
+    if (network.type !== 10) {
+      const apiNetwork = arkts.Network.getDefault(network.type);
+      if (apiNetwork) {
+        network = Object.assign<StoredNetwork, arkts.Network>(network, apiNetwork);
+      }
+    }
+    if (activePeer) {
+      network.activePeer = activePeer;
+    }
+
+    this._network = network;
+    this.arkjs.crypto.setNetworkVersion(this._network.version);
+
+    this._api = new arkts.Client(this._network);
+    this.findGoodPeer();
   }
 
   public async findGoodPeer() {


### PR DESCRIPTION
This is as a result of the devnet v2 changes that were made I think. Whenever it sets the network in the API provider, it tries to overwrite the network data with anything stored in the ark-ts config (to make sure it's not out of date). The problem was, any new custom networks had the same "type" as mainnet, meaning all the data for the custom network was overwritten by mainnet data.