### PR TITLE
fix: don't broadcast if there are no peers

### DIFF
--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -323,6 +323,10 @@ export class ArkApiProvider {
   }
 
   private broadcastTransaction(transaction: arkts.Transaction) {
+    if (!this._network.peerList || !this._network.peerList.length) {
+      return;
+    }
+
     for (const peer of this._network.peerList.slice(0, 10)) {
       this.postTransaction(transaction, peer, false).subscribe(
         null,


### PR DESCRIPTION
Skip peer broadcast if can't get peers (this happens when adding a local testnet, for example). It just saves on some messy error pages and poor UX.