### PR TITLE
fix: disable send buttons

### DIFF
--- a/src/components/confirm-transaction/confirm-transaction.ts
+++ b/src/components/confirm-transaction/confirm-transaction.ts
@@ -15,6 +15,7 @@ export class ConfirmTransactionComponent {
 
   @Input('wallet') wallet: Wallet;
 
+  @Output('onClosed') onClosed: EventEmitter<string> = new EventEmitter();
   @Output('onError') onError: EventEmitter<string> = new EventEmitter();
   @Output('onConfirm') onConfirm: EventEmitter<Transaction> = new EventEmitter();
 
@@ -36,9 +37,15 @@ export class ConfirmTransactionComponent {
         }, { cssClass: 'inset-modal-send', enableBackdropDismiss: true });
 
         modal.onDidDismiss((result) => {
-          if (lodash.isUndefined(result)) { return; }
+          if (lodash.isUndefined(result)) {
+            return this.onClosed.emit();
+          }
 
-          if (!result.status) { return this.presentWrongModal(result); }
+          if (!result.status) {
+            this.onClosed.emit();
+
+            return this.presentWrongModal(result);
+          }
 
           this.onConfirm.emit(tx);
 

--- a/src/modals/confirm-transaction/confirm-transaction.html
+++ b/src/modals/confirm-transaction/confirm-transaction.html
@@ -81,7 +81,7 @@
   <button ion-button
           class="button-continue"
           (click)="broadcast()"
-          [disabled]="addressCheckResult?.type === checkTypes.Error || hasBroadcast">
+          [disabled]="hasBroadcast || addressCheckResult?.type === checkTypes.Error">
     {{ 'TRANSACTIONS_PAGE.SEND' | translate }}
   </button>
 </ion-footer>

--- a/src/modals/confirm-transaction/confirm-transaction.ts
+++ b/src/modals/confirm-transaction/confirm-transaction.ts
@@ -54,6 +54,12 @@ export class ConfirmTransactionModal implements OnDestroy {
   }
 
   broadcast() {
+    // TODO: The DOM doesn't update very quickly on a mobile device to disable the button.
+    //       This is a hack to stop the button sending multiple times.
+    if (this.hasBroadcast) {
+      return;
+    }
+
     this.hasBroadcast = true;
     this.arkApiProvider.postTransaction(this.transaction)
       .subscribe(() => {

--- a/src/pages/transaction/transaction-send/transaction-send.html
+++ b/src/pages/transaction/transaction-send/transaction-send.html
@@ -73,7 +73,12 @@
       </ion-row>
       <ion-row>
         <ion-col align-self-end>
-          <button ion-button class="button-continue" (click)="send()">{{ 'TRANSACTIONS_PAGE.SEND' | translate }}</button>
+          <button ion-button
+                  class="button-continue"
+                  (click)="send()"
+                  [disabled]="hasSent">
+            {{ 'TRANSACTIONS_PAGE.SEND' | translate }}
+          </button>
         </ion-col>
       </ion-row>
     </ion-grid>


### PR DESCRIPTION
Disable send buttons on click. Second send button doesn't update DOM in time, so it's still possible to click many times (I spent 2 hours trying to fix this). Resorted in a check to see if the button has already been pressed, and to not do the same process again.

Resolves #192 