### PR TITLE
Always display 2 decimal digit

### DIFF
--- a/src/pages/delegates/delegate-detail/delegate-detail.html
+++ b/src/pages/delegates/delegate-detail/delegate-detail.html
@@ -26,7 +26,7 @@
           <ion-label stacked>
             <p>{{ 'DELEGATES_PAGE.APPROVAL' | translate }}</p>
             <h4 item-content class="content">
-              {{ delegate?.approval }}%
+              {{ (delegate?.approval).toFixed(2) }}%
             </h4>
           </ion-label>
         </ion-item>
@@ -36,7 +36,7 @@
           <ion-label stacked>
             <p>{{ 'DELEGATES_PAGE.UPTIME' | translate }}</p>
             <h4 item-content class="content">
-              {{ delegate?.productivity }}%
+              {{ (delegate?.productivity).toFixed(2) }}%
             </h4>
           </ion-label>
         </ion-item>


### PR DESCRIPTION
To indicate the precision, displaying 2 decimal digits of approval percentage and productivity.

Many a times, approval displays as '1%'(shown as integer), now it will display as '1.00%'(float)
This shows precision and makes information uniform in every case.