### PR TITLE
fix: remove webview

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -21,7 +21,7 @@
     <preference name="SplashScreen" value="screen" />
     <preference name="SplashScreenDelay" value="5000" />
     <preference name="SplashScreenSpinnerColor" value="#0000ff" />
-    <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
+    <preference name="CordovaWebViewEngine" value="CDVUIWebViewEngine" />
     <preference name="WKSuspendInBackground" value="false" />
     <preference name="KeyboardResizeMode" value="native" />
     <platform name="android">
@@ -102,9 +102,6 @@
     <plugin name="cordova-plugin-device" spec="^2.0.2" />
     <plugin name="cordova-plugin-statusbar" spec="^2.4.2" />
     <plugin name="cordova-plugin-vibration" spec="^3.1.0" />
-    <plugin name="cordova-plugin-ionic-webview" spec="^2.2.0">
-        <variable name="ANDROID_SUPPORT_ANNOTATIONS_VERSION" value="27.+" />
-    </plugin>
     <plugin name="cordova-plugin-inappbrowser" spec="^3.0.0" />
     <plugin name="cordova-clipboard" spec="^1.2.1" />
     <plugin name="cordova-plugin-x-socialsharing" spec="^5.4.1" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
             "integrity": "sha512-7JxZZAYFSCc0tP6+NrRn3b2Cd1b9d+a3+OfwVNyNsNd2unelqUMko2hm0KLbC8BXcXt/OILg1E/ZgLAXSS47nw==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "source-map": "^0.5.6",
-                "typescript": "~2.6.1",
-                "webpack-sources": "^1.0.1"
+                "loader-utils": "1.1.0",
+                "source-map": "0.5.7",
+                "typescript": "2.6.2",
+                "webpack-sources": "1.0.2"
             },
             "dependencies": {
                 "typescript": {
@@ -30,10 +30,10 @@
             "integrity": "sha512-zABk/iP7YX5SVbmK4e+IX7j2d0D37MQJQiKgWdV3JzfvVJhNJzddiirtT980pIafoq+KyvTgVwXtc+vnux0oeQ==",
             "dev": true,
             "requires": {
-                "ajv": "~5.5.1",
-                "chokidar": "^1.7.0",
-                "rxjs": "^5.5.6",
-                "source-map": "^0.5.6"
+                "ajv": "5.5.2",
+                "chokidar": "1.7.0",
+                "rxjs": "5.5.10",
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "ajv": {
@@ -42,10 +42,10 @@
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "dev": true,
                     "requires": {
-                        "co": "^4.6.0",
-                        "fast-deep-equal": "^1.0.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.3.0"
+                        "co": "4.6.0",
+                        "fast-deep-equal": "1.0.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
                     }
                 },
                 "rxjs": {
@@ -65,8 +65,8 @@
             "integrity": "sha512-B6zZoqvHaTJy+vVdA6EtlxnCdGMa5elCa4j9lQLC3JI8DLvMXUWkCIPVbPzJ/GSRR9nsKWpvYMYaJyfBDUqfhw==",
             "dev": true,
             "requires": {
-                "@ngtools/json-schema": "^1.1.0",
-                "rxjs": "^5.5.6"
+                "@ngtools/json-schema": "1.2.0",
+                "rxjs": "5.5.10"
             },
             "dependencies": {
                 "rxjs": {
@@ -93,58 +93,58 @@
                 "@ngtools/webpack": "1.10.2",
                 "@schematics/angular": "0.3.2",
                 "@schematics/package-update": "0.3.2",
-                "ajv": "^6.1.1",
-                "autoprefixer": "^7.2.3",
-                "cache-loader": "^1.2.0",
-                "chalk": "~2.2.0",
-                "circular-dependency-plugin": "^4.2.1",
-                "clean-css": "^4.1.11",
-                "common-tags": "^1.3.1",
-                "copy-webpack-plugin": "~4.4.1",
-                "core-object": "^3.1.0",
-                "denodeify": "^1.2.1",
-                "ember-cli-string-utils": "^1.0.0",
-                "extract-text-webpack-plugin": "^3.0.2",
-                "file-loader": "^1.1.5",
-                "fs-extra": "^4.0.0",
-                "glob": "^7.0.3",
-                "html-webpack-plugin": "^2.29.0",
-                "istanbul-instrumenter-loader": "^3.0.0",
-                "karma-source-map-support": "^1.2.0",
-                "less": "^2.7.2",
-                "less-loader": "^4.0.5",
-                "license-webpack-plugin": "^1.0.0",
+                "ajv": "6.5.4",
+                "autoprefixer": "7.2.6",
+                "cache-loader": "1.2.2",
+                "chalk": "2.2.2",
+                "circular-dependency-plugin": "4.4.0",
+                "clean-css": "4.2.1",
+                "common-tags": "1.8.0",
+                "copy-webpack-plugin": "4.4.3",
+                "core-object": "3.1.5",
+                "denodeify": "1.2.1",
+                "ember-cli-string-utils": "1.1.0",
+                "extract-text-webpack-plugin": "3.0.2",
+                "file-loader": "1.1.11",
+                "fs-extra": "4.0.2",
+                "glob": "7.1.3",
+                "html-webpack-plugin": "2.30.1",
+                "istanbul-instrumenter-loader": "3.0.1",
+                "karma-source-map-support": "1.3.0",
+                "less": "2.7.3",
+                "less-loader": "4.1.0",
+                "license-webpack-plugin": "1.5.0",
                 "loader-utils": "1.1.0",
-                "lodash": "^4.11.1",
-                "memory-fs": "^0.4.1",
-                "minimatch": "^3.0.4",
-                "node-modules-path": "^1.0.0",
-                "node-sass": "^4.7.2",
-                "nopt": "^4.0.1",
-                "opn": "~5.1.0",
-                "portfinder": "~1.0.12",
-                "postcss": "^6.0.16",
-                "postcss-import": "^11.0.0",
-                "postcss-loader": "^2.0.10",
-                "postcss-url": "^7.1.2",
-                "raw-loader": "^0.5.1",
-                "resolve": "^1.1.7",
-                "rxjs": "^5.5.6",
-                "sass-loader": "^6.0.6",
-                "semver": "^5.1.0",
-                "silent-error": "^1.0.0",
-                "source-map-support": "^0.4.1",
-                "style-loader": "^0.19.1",
-                "stylus": "^0.54.5",
-                "stylus-loader": "^3.0.1",
-                "uglifyjs-webpack-plugin": "^1.1.8",
-                "url-loader": "^0.6.2",
-                "webpack": "~3.11.0",
-                "webpack-dev-middleware": "~1.12.0",
-                "webpack-dev-server": "~2.11.0",
-                "webpack-merge": "^4.1.0",
-                "webpack-sources": "^1.0.0",
-                "webpack-subresource-integrity": "^1.0.1"
+                "lodash": "4.17.11",
+                "memory-fs": "0.4.1",
+                "minimatch": "3.0.4",
+                "node-modules-path": "1.0.2",
+                "node-sass": "4.9.0",
+                "nopt": "4.0.1",
+                "opn": "5.1.0",
+                "portfinder": "1.0.18",
+                "postcss": "6.0.23",
+                "postcss-import": "11.1.0",
+                "postcss-loader": "2.1.6",
+                "postcss-url": "7.3.2",
+                "raw-loader": "0.5.1",
+                "resolve": "1.8.1",
+                "rxjs": "5.5.10",
+                "sass-loader": "6.0.7",
+                "semver": "5.4.1",
+                "silent-error": "1.1.1",
+                "source-map-support": "0.4.18",
+                "style-loader": "0.19.1",
+                "stylus": "0.54.5",
+                "stylus-loader": "3.0.2",
+                "uglifyjs-webpack-plugin": "1.3.0",
+                "url-loader": "0.6.2",
+                "webpack": "3.11.0",
+                "webpack-dev-middleware": "1.12.2",
+                "webpack-dev-server": "2.11.3",
+                "webpack-merge": "4.1.4",
+                "webpack-sources": "1.0.2",
+                "webpack-subresource-integrity": "1.2.0"
             },
             "dependencies": {
                 "@angular-devkit/build-optimizer": {
@@ -153,10 +153,10 @@
                     "integrity": "sha512-U0BCZtThq5rUfY08shHXpxe8ZhSsiYB/cJjUvAWRTs/ORrs8pbngS6xwseQws8d/vHoVrtqGD9GU9h8AmFRERQ==",
                     "dev": true,
                     "requires": {
-                        "loader-utils": "^1.1.0",
-                        "source-map": "^0.5.6",
-                        "typescript": "~2.6.2",
-                        "webpack-sources": "^1.0.1"
+                        "loader-utils": "1.1.0",
+                        "source-map": "0.5.7",
+                        "typescript": "2.6.2",
+                        "webpack-sources": "1.0.2"
                     }
                 },
                 "ajv": {
@@ -165,10 +165,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "chalk": {
@@ -177,9 +177,9 @@
                     "integrity": "sha512-LvixLAQ4MYhbf7hgL4o5PeK32gJKvVzDRiSNIApDofQvyhl8adgG2lJVXn4+ekQoK7HL9RF8lqxwerpe0x2pCw==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.1.0",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^4.0.0"
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
                     }
                 },
                 "commander": {
@@ -206,8 +206,8 @@
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.4"
                     }
                 },
                 "rxjs": {
@@ -231,8 +231,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "~2.13.0",
-                        "source-map": "~0.6.1"
+                        "commander": "2.13.0",
+                        "source-map": "0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -249,14 +249,14 @@
                     "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
                     "dev": true,
                     "requires": {
-                        "cacache": "^10.0.4",
-                        "find-cache-dir": "^1.0.0",
-                        "schema-utils": "^0.4.5",
-                        "serialize-javascript": "^1.4.0",
-                        "source-map": "^0.6.1",
-                        "uglify-es": "^3.3.4",
-                        "webpack-sources": "^1.1.0",
-                        "worker-farm": "^1.5.2"
+                        "cacache": "10.0.4",
+                        "find-cache-dir": "1.0.0",
+                        "schema-utils": "0.4.7",
+                        "serialize-javascript": "1.5.0",
+                        "source-map": "0.6.1",
+                        "uglify-es": "3.3.9",
+                        "webpack-sources": "1.3.0",
+                        "worker-farm": "1.6.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -271,8 +271,8 @@
                             "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
                             "dev": true,
                             "requires": {
-                                "source-list-map": "^2.0.0",
-                                "source-map": "~0.6.1"
+                                "source-list-map": "2.0.0",
+                                "source-map": "0.6.1"
                             }
                         }
                     }
@@ -284,7 +284,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.11.tgz",
             "integrity": "sha512-LniJjGAeftUJDJh+2+LEjltcGen08C/VMxQ/eUYmesytKy1sN+MWzh3GbpKfEWtWmyUsYTG9lAAJNo3L3jPwsw==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/compiler": {
@@ -292,7 +292,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.11.tgz",
             "integrity": "sha512-ICvB1ud1mxaXUYLb8vhJqiLhGBVocAZGxoHTglv6hMkbrRYcnlB3FZJFOzBvtj+krkd1jamoYLI43UAmesqQ6Q==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/compiler-cli": {
@@ -300,10 +300,10 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.11.tgz",
             "integrity": "sha512-dwrQ0yxoCM/XzKzlm7pTsyg4/6ECjT9emZufGj8t12bLMO8NDn1IJOsqXJA1+onEgQKhlr0Ziwi+96TvDTb1Cg==",
             "requires": {
-                "chokidar": "^1.4.2",
-                "minimist": "^1.2.0",
-                "reflect-metadata": "^0.1.2",
-                "tsickle": "^0.27.2"
+                "chokidar": "1.7.0",
+                "minimist": "1.2.0",
+                "reflect-metadata": "0.1.10",
+                "tsickle": "0.27.5"
             }
         },
         "@angular/core": {
@@ -311,7 +311,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.11.tgz",
             "integrity": "sha512-h2vpvXNAdOqKzbVaZcHnHGMT5A8uDnizk6FgGq6SPyw9s3d+/VxZ9LJaPjUk3g2lICA7og1tUel+2YfF971MlQ==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/forms": {
@@ -319,7 +319,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.11.tgz",
             "integrity": "sha512-wBllFlIubPclAFRXUc84Kc7TMeKOftzrQraVZ7ooTNeFLLa/FZLN2K8HGyRde8X/XDsMu1XAmjNfkz++spwTzA==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/http": {
@@ -327,7 +327,7 @@
             "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.2.11.tgz",
             "integrity": "sha512-eR7wNXh1+6MpcQNb3sq4bJVX03dx50Wl3kpPG+Q7N1VSL0oPQSobaTrR17ac3oFCEfSJn6kkUCqtUXha6wcNHg==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/platform-browser": {
@@ -335,7 +335,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.11.tgz",
             "integrity": "sha512-6YZ4IpBFqXx88vEzBZG2WWnaSYXbFWDgG0iT+bZPHAfwsbmqbcMcs7Ogu+XZ4VmK02dTqbrFh7U4P2W+sqrzow==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/platform-browser-dynamic": {
@@ -343,7 +343,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.11.tgz",
             "integrity": "sha512-5kKPNULcXNwkyBjpHfF+pq+Yxi8Zl866YSOK9t8txoiQ9Ctw97kMkEJcTetk6MJgBp/NP3YyjtoTAm8oXLerug==",
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@angular/router": {
@@ -352,7 +352,7 @@
             "integrity": "sha512-NT8xYl7Vr3qPygisek3PlXqNROEjg48GXOEsDEc7c8lDBo3EB9Tf328fWJD0GbLtXZNhmmNNxwIe+qqPFFhFAA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@babel/code-frame": {
@@ -361,7 +361,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.0.0"
             }
         },
         "@babel/generator": {
@@ -370,11 +370,11 @@
             "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.1.3",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.10",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/types": "7.1.3",
+                "jsesc": "2.5.1",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             },
             "dependencies": {
                 "jsesc": {
@@ -391,9 +391,9 @@
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.1.2",
+                "@babel/types": "7.1.3"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -402,7 +402,7 @@
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.3"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -411,7 +411,7 @@
             "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.1.3"
             }
         },
         "@babel/highlight": {
@@ -420,9 +420,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.3.0",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
             },
             "dependencies": {
                 "js-tokens": {
@@ -445,9 +445,9 @@
             "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.1.2",
-                "@babel/types": "^7.1.2"
+                "@babel/code-frame": "7.0.0",
+                "@babel/parser": "7.1.3",
+                "@babel/types": "7.1.3"
             }
         },
         "@babel/traverse": {
@@ -456,15 +456,15 @@
             "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.1.3",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.1.3",
-                "@babel/types": "^7.1.3",
-                "debug": "^3.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.10"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.1.3",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "@babel/parser": "7.1.3",
+                "@babel/types": "7.1.3",
+                "debug": "3.2.6",
+                "globals": "11.8.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "debug": {
@@ -473,7 +473,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "globals": {
@@ -496,9 +496,9 @@
             "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.10",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "2.0.0"
             },
             "dependencies": {
                 "to-fast-properties": {
@@ -581,50 +581,34 @@
             "dev": true,
             "requires": {
                 "@angular-devkit/build-optimizer": "0.0.35",
-                "autoprefixer": "^7.2.6",
-                "chalk": "^2.4.0",
-                "chokidar": "^1.7.0",
-                "clean-css": "^4.1.11",
-                "cross-spawn": "^5.1.0",
-                "dotenv-webpack": "^1.5.7",
-                "express": "^4.16.3",
-                "fs-extra": "^4.0.2",
-                "glob": "^7.1.2",
-                "json-loader": "^0.5.7",
+                "autoprefixer": "7.2.6",
+                "chalk": "2.4.1",
+                "chokidar": "1.7.0",
+                "clean-css": "4.2.1",
+                "cross-spawn": "5.1.0",
+                "dotenv-webpack": "1.5.7",
+                "express": "4.16.4",
+                "fs-extra": "4.0.2",
+                "glob": "7.1.3",
+                "json-loader": "0.5.7",
                 "node-sass": "4.9.0",
-                "os-name": "^2.0.1",
-                "postcss": "^6.0.21",
-                "proxy-middleware": "^0.15.0",
-                "reflect-metadata": "^0.1.10",
+                "os-name": "2.0.1",
+                "postcss": "6.0.23",
+                "proxy-middleware": "0.15.0",
+                "reflect-metadata": "0.1.10",
                 "rollup": "0.50.0",
                 "rollup-plugin-commonjs": "8.2.6",
                 "rollup-plugin-node-resolve": "3.0.0",
-                "source-map": "^0.6.1",
-                "tiny-lr": "^1.1.1",
-                "tslint": "^5.8.0",
-                "tslint-eslint-rules": "^4.1.1",
+                "source-map": "0.6.1",
+                "tiny-lr": "1.1.1",
+                "tslint": "5.11.0",
+                "tslint-eslint-rules": "4.1.1",
                 "uglify-es": "3.2.2",
                 "webpack": "3.8.1",
                 "ws": "3.3.2",
-                "xml2js": "^0.4.19"
+                "xml2js": "0.4.19"
             },
             "dependencies": {
-                "accepts": {
-                    "version": "1.3.5",
-                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-                    "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-                    "dev": true,
-                    "requires": {
-                        "mime-types": "~2.1.18",
-                        "negotiator": "0.6.1"
-                    }
-                },
-                "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-                    "dev": true
-                },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -637,25 +621,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "body-parser": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-                    "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-                    "dev": true,
-                    "requires": {
-                        "bytes": "3.0.0",
-                        "content-type": "~1.0.4",
-                        "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "http-errors": "~1.6.3",
-                        "iconv-lite": "0.4.23",
-                        "on-finished": "~2.3.0",
-                        "qs": "6.5.2",
-                        "raw-body": "2.3.3",
-                        "type-is": "~1.6.16"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "camelcase": {
@@ -670,89 +636,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "clean-css": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-                    "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "~0.6.0"
-                    }
-                },
-                "commander": {
-                    "version": "2.12.2",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-                    "dev": true
-                },
-                "depd": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-                    "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-                    "dev": true
-                },
-                "encodeurl": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-                    "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-                    "dev": true
-                },
-                "express": {
-                    "version": "4.16.4",
-                    "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-                    "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-                    "dev": true,
-                    "requires": {
-                        "accepts": "~1.3.5",
-                        "array-flatten": "1.1.1",
-                        "body-parser": "1.18.3",
-                        "content-disposition": "0.5.2",
-                        "content-type": "~1.0.4",
-                        "cookie": "0.3.1",
-                        "cookie-signature": "1.0.6",
-                        "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
-                        "finalhandler": "1.1.1",
-                        "fresh": "0.5.2",
-                        "merge-descriptors": "1.0.1",
-                        "methods": "~1.1.2",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "path-to-regexp": "0.1.7",
-                        "proxy-addr": "~2.0.4",
-                        "qs": "6.5.2",
-                        "range-parser": "~1.2.0",
-                        "safe-buffer": "5.1.2",
-                        "send": "0.16.2",
-                        "serve-static": "1.13.2",
-                        "setprototypeof": "1.1.0",
-                        "statuses": "~1.4.0",
-                        "type-is": "~1.6.16",
-                        "utils-merge": "1.0.1",
-                        "vary": "~1.1.2"
-                    }
-                },
-                "finalhandler": {
-                    "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-                    "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "2.6.9",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "statuses": "~1.4.0",
-                        "unpipe": "~1.0.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "find-up": {
@@ -761,54 +647,13 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "http-errors": {
-                    "version": "1.6.3",
-                    "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-                    "dev": true,
-                    "requires": {
-                        "depd": "~1.1.2",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.1.0",
-                        "statuses": ">= 1.4.0 < 2"
-                    }
-                },
-                "iconv-lite": {
-                    "version": "0.4.23",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-                    "dev": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "ipaddr.js": {
-                    "version": "1.8.0",
-                    "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-                    "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
@@ -823,25 +668,10 @@
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "strip-bom": "^3.0.0"
-                    }
-                },
-                "mime-db": {
-                    "version": "1.37.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-                    "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.1.21",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-                    "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "~1.37.0"
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "os-locale": {
@@ -850,16 +680,10 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                     }
-                },
-                "path-to-regexp": {
-                    "version": "0.1.7",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-                    "dev": true
                 },
                 "path-type": {
                     "version": "2.0.0",
@@ -867,46 +691,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "^2.0.0"
-                    }
-                },
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "proxy-addr": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-                    "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-                    "dev": true,
-                    "requires": {
-                        "forwarded": "~0.1.2",
-                        "ipaddr.js": "1.8.0"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-                    "dev": true
-                },
-                "raw-body": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-                    "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-                    "dev": true,
-                    "requires": {
-                        "bytes": "3.0.0",
-                        "http-errors": "1.6.3",
-                        "iconv-lite": "0.4.23",
-                        "unpipe": "1.0.0"
+                        "pify": "2.3.0"
                     }
                 },
                 "read-pkg": {
@@ -915,9 +700,9 @@
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^2.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^2.0.0"
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -926,47 +711,8 @@
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                     "dev": true,
                     "requires": {
-                        "find-up": "^2.0.0",
-                        "read-pkg": "^2.0.0"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                },
-                "send": {
-                    "version": "0.16.2",
-                    "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-                    "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-                    "dev": true,
-                    "requires": {
-                        "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "destroy": "~1.0.4",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
-                        "fresh": "0.5.2",
-                        "http-errors": "~1.6.2",
-                        "mime": "1.4.1",
-                        "ms": "2.0.0",
-                        "on-finished": "~2.3.0",
-                        "range-parser": "~1.2.0",
-                        "statuses": "~1.4.0"
-                    }
-                },
-                "serve-static": {
-                    "version": "1.13.2",
-                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-                    "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-                    "dev": true,
-                    "requires": {
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "parseurl": "~1.3.2",
-                        "send": "0.16.2"
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
                     }
                 },
                 "source-map": {
@@ -975,20 +721,14 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 },
-                "statuses": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-                    "dev": true
-                },
                 "string-width": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -997,7 +737,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "strip-bom": {
@@ -1012,27 +752,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                },
-                "type-is": {
-                    "version": "1.6.16",
-                    "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-                    "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-                    "dev": true,
-                    "requires": {
-                        "media-typer": "0.3.0",
-                        "mime-types": "~2.1.18"
-                    }
-                },
-                "uglify-es": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
-                    "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
-                    "dev": true,
-                    "requires": {
-                        "commander": "~2.12.1",
-                        "source-map": "~0.6.1"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "webpack": {
@@ -1041,28 +761,28 @@
                     "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
                     "dev": true,
                     "requires": {
-                        "acorn": "^5.0.0",
-                        "acorn-dynamic-import": "^2.0.0",
-                        "ajv": "^5.1.5",
-                        "ajv-keywords": "^2.0.0",
-                        "async": "^2.1.2",
-                        "enhanced-resolve": "^3.4.0",
-                        "escope": "^3.6.0",
-                        "interpret": "^1.0.0",
-                        "json-loader": "^0.5.4",
-                        "json5": "^0.5.1",
-                        "loader-runner": "^2.3.0",
-                        "loader-utils": "^1.1.0",
-                        "memory-fs": "~0.4.1",
-                        "mkdirp": "~0.5.0",
-                        "node-libs-browser": "^2.0.0",
-                        "source-map": "^0.5.3",
-                        "supports-color": "^4.2.1",
-                        "tapable": "^0.2.7",
-                        "uglifyjs-webpack-plugin": "^0.4.6",
-                        "watchpack": "^1.4.0",
-                        "webpack-sources": "^1.0.1",
-                        "yargs": "^8.0.2"
+                        "acorn": "5.7.3",
+                        "acorn-dynamic-import": "2.0.2",
+                        "ajv": "5.3.0",
+                        "ajv-keywords": "2.1.1",
+                        "async": "2.6.0",
+                        "enhanced-resolve": "3.4.1",
+                        "escope": "3.6.0",
+                        "interpret": "1.1.0",
+                        "json-loader": "0.5.7",
+                        "json5": "0.5.1",
+                        "loader-runner": "2.3.0",
+                        "loader-utils": "1.1.0",
+                        "memory-fs": "0.4.1",
+                        "mkdirp": "0.5.1",
+                        "node-libs-browser": "2.0.0",
+                        "source-map": "0.5.7",
+                        "supports-color": "4.5.0",
+                        "tapable": "0.2.8",
+                        "uglifyjs-webpack-plugin": "0.4.6",
+                        "watchpack": "1.4.0",
+                        "webpack-sources": "1.0.2",
+                        "yargs": "8.0.2"
                     },
                     "dependencies": {
                         "has-flag": {
@@ -1083,7 +803,7 @@
                             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^2.0.0"
+                                "has-flag": "2.0.0"
                             }
                         }
                     }
@@ -1100,9 +820,9 @@
                     "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "~1.0.0",
-                        "safe-buffer": "~5.1.0",
-                        "ultron": "~1.1.0"
+                        "async-limiter": "1.0.0",
+                        "safe-buffer": "5.1.1",
+                        "ultron": "1.1.0"
                     }
                 },
                 "yargs": {
@@ -1111,19 +831,19 @@
                     "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "read-pkg-up": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^7.0.0"
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -1132,7 +852,7 @@
                     "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -1144,7 +864,7 @@
             "requires": {
                 "localforage": "1.7.1",
                 "localforage-cordovasqlitedriver": "1.7.0",
-                "tslib": "^1.7.1"
+                "tslib": "1.8.0"
             }
         },
         "@ngtools/json-schema": {
@@ -1159,14 +879,14 @@
             "integrity": "sha512-3u2zg2rarG3qNLSukBClGADWuq/iNn5SQtlSeAbfKzwBeyLGbF0gN1z1tVx1Bcr8YwFzR6NdRePQmJGcoqq1fg==",
             "dev": true,
             "requires": {
-                "chalk": "~2.2.0",
-                "enhanced-resolve": "^3.1.0",
-                "loader-utils": "^1.0.2",
-                "magic-string": "^0.22.3",
-                "semver": "^5.3.0",
-                "source-map": "^0.5.6",
-                "tree-kill": "^1.0.0",
-                "webpack-sources": "^1.1.0"
+                "chalk": "2.2.2",
+                "enhanced-resolve": "3.4.1",
+                "loader-utils": "1.1.0",
+                "magic-string": "0.22.4",
+                "semver": "5.4.1",
+                "source-map": "0.5.7",
+                "tree-kill": "1.2.0",
+                "webpack-sources": "1.3.0"
             },
             "dependencies": {
                 "chalk": {
@@ -1175,9 +895,9 @@
                     "integrity": "sha512-LvixLAQ4MYhbf7hgL4o5PeK32gJKvVzDRiSNIApDofQvyhl8adgG2lJVXn4+ekQoK7HL9RF8lqxwerpe0x2pCw==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.1.0",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^4.0.0"
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "4.5.0"
                     }
                 },
                 "webpack-sources": {
@@ -1186,8 +906,8 @@
                     "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
                     "dev": true,
                     "requires": {
-                        "source-list-map": "^2.0.0",
-                        "source-map": "~0.6.1"
+                        "source-list-map": "2.0.0",
+                        "source-map": "0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -1216,7 +936,7 @@
             "integrity": "sha512-Elrk0BA951s0ScFZU0AWrpUeJBYVR52DZ1QTIO5R0AhwEd1PW4olI8szPLGQlVW5Sd6H0FA/fyFLIvn2r9v6Rw==",
             "dev": true,
             "requires": {
-                "typescript": "~2.6.2"
+                "typescript": "2.6.2"
             },
             "dependencies": {
                 "typescript": {
@@ -1233,9 +953,9 @@
             "integrity": "sha512-7aVP4994Hu8vRdTTohXkfGWEwLhrdNP3EZnWyBootm5zshWqlQojUGweZe5zwewsKcixeVOiy2YtW+aI4aGSLA==",
             "dev": true,
             "requires": {
-                "rxjs": "^5.5.6",
-                "semver": "^5.3.0",
-                "semver-intersect": "^1.1.2"
+                "rxjs": "5.5.10",
+                "semver": "5.4.1",
+                "semver-intersect": "1.4.0"
             },
             "dependencies": {
                 "rxjs": {
@@ -1270,7 +990,7 @@
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "*"
+                "@types/node": "8.9.4"
             }
         },
         "@types/jasmine": {
@@ -1291,7 +1011,7 @@
             "integrity": "sha512-tBf1QR8xAayQfI1xD+SMSNDMxi+aCYKEhjgVXTZt3sgxS2XusNX3jM6jJbFoY/ar1CK/PaYJoPkWs/mwcwgOqw==",
             "dev": true,
             "requires": {
-                "moment": ">=2.14.0"
+                "moment": "2.22.2"
             }
         },
         "@types/node": {
@@ -1310,10 +1030,10 @@
             "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
             "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
             "requires": {
-                "@types/caseless": "*",
-                "@types/form-data": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*"
+                "@types/caseless": "0.12.1",
+                "@types/form-data": "2.2.1",
+                "@types/node": "8.9.4",
+                "@types/tough-cookie": "2.3.3"
             }
         },
         "@types/rx": {
@@ -1321,18 +1041,18 @@
             "resolved": "http://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
             "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
             "requires": {
-                "@types/rx-core": "*",
-                "@types/rx-core-binding": "*",
-                "@types/rx-lite": "*",
-                "@types/rx-lite-aggregates": "*",
-                "@types/rx-lite-async": "*",
-                "@types/rx-lite-backpressure": "*",
-                "@types/rx-lite-coincidence": "*",
-                "@types/rx-lite-experimental": "*",
-                "@types/rx-lite-joinpatterns": "*",
-                "@types/rx-lite-testing": "*",
-                "@types/rx-lite-time": "*",
-                "@types/rx-lite-virtualtime": "*"
+                "@types/rx-core": "4.0.3",
+                "@types/rx-core-binding": "4.0.4",
+                "@types/rx-lite": "4.0.6",
+                "@types/rx-lite-aggregates": "4.0.3",
+                "@types/rx-lite-async": "4.0.2",
+                "@types/rx-lite-backpressure": "4.0.3",
+                "@types/rx-lite-coincidence": "4.0.3",
+                "@types/rx-lite-experimental": "4.0.1",
+                "@types/rx-lite-joinpatterns": "4.0.1",
+                "@types/rx-lite-testing": "4.0.1",
+                "@types/rx-lite-time": "4.0.3",
+                "@types/rx-lite-virtualtime": "4.0.3"
             }
         },
         "@types/rx-core": {
@@ -1345,7 +1065,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
             "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
             "requires": {
-                "@types/rx-core": "*"
+                "@types/rx-core": "4.0.3"
             }
         },
         "@types/rx-lite": {
@@ -1353,8 +1073,8 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.6.tgz",
             "integrity": "sha512-oYiDrFIcor9zDm0VDUca1UbROiMYBxMLMaM6qzz4ADAfOmA9r1dYEcAFH+2fsPI5BCCjPvV9pWC3X3flbrvs7w==",
             "requires": {
-                "@types/rx-core": "*",
-                "@types/rx-core-binding": "*"
+                "@types/rx-core": "4.0.3",
+                "@types/rx-core-binding": "4.0.4"
             }
         },
         "@types/rx-lite-aggregates": {
@@ -1362,7 +1082,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
             "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-async": {
@@ -1370,7 +1090,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
             "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-backpressure": {
@@ -1378,7 +1098,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
             "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-coincidence": {
@@ -1386,7 +1106,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
             "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-experimental": {
@@ -1394,7 +1114,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
             "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-joinpatterns": {
@@ -1402,7 +1122,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
             "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-testing": {
@@ -1410,7 +1130,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
             "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
             "requires": {
-                "@types/rx-lite-virtualtime": "*"
+                "@types/rx-lite-virtualtime": "4.0.3"
             }
         },
         "@types/rx-lite-time": {
@@ -1418,7 +1138,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
             "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/rx-lite-virtualtime": {
@@ -1426,7 +1146,7 @@
             "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
             "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
             "requires": {
-                "@types/rx-lite": "*"
+                "@types/rx-lite": "4.0.6"
             }
         },
         "@types/selenium-webdriver": {
@@ -1458,7 +1178,7 @@
             "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "8.9.4"
             }
         },
         "abbrev": {
@@ -1473,9 +1193,15 @@
             "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.16",
+                "mime-types": "2.1.17",
                 "negotiator": "0.6.1"
             }
+        },
+        "acorn": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+            "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+            "dev": true
         },
         "acorn-dynamic-import": {
             "version": "2.0.2",
@@ -1483,7 +1209,7 @@
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
             "dev": true,
             "requires": {
-                "acorn": "^4.0.3"
+                "acorn": "4.0.13"
             },
             "dependencies": {
                 "acorn": {
@@ -1505,10 +1231,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
             "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
@@ -1523,9 +1249,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2",
-                "longest": "^1.0.1",
-                "repeat-string": "^1.5.2"
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
             }
         },
         "amdefine": {
@@ -1539,7 +1265,7 @@
             "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-1.3.0.tgz",
             "integrity": "sha512-d/i1G16Oaw/T1EvskUA7Oo1vIQVK/0ZlpQgZfYVBwg6v/9FBE3QV66g5N1/bTHpRml8tFLxh+KoTw5DokK9c+A==",
             "requires": {
-                "semver": "^5.4.1"
+                "semver": "5.4.1"
             }
         },
         "angular2-qrcode": {
@@ -1547,7 +1273,7 @@
             "resolved": "https://registry.npmjs.org/angular2-qrcode/-/angular2-qrcode-2.0.1.tgz",
             "integrity": "sha1-G05lwwJpS1B4ygb3ETj35DZ3VNw=",
             "requires": {
-                "qrious": "^2.2.0"
+                "qrious": "2.3.0"
             }
         },
         "ansi-html": {
@@ -1568,7 +1294,7 @@
             "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
             "dev": true,
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.1"
             }
         },
         "anymatch": {
@@ -1576,8 +1302,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "requires": {
-                "micromatch": "^2.1.5",
-                "normalize-path": "^2.0.0"
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
             }
         },
         "append-transform": {
@@ -1586,7 +1312,7 @@
             "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
             "dev": true,
             "requires": {
-                "default-require-extensions": "^2.0.0"
+                "default-require-extensions": "2.0.0"
             }
         },
         "aproba": {
@@ -1601,8 +1327,8 @@
             "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
             "dev": true,
             "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "delegates": "1.0.0",
+                "readable-stream": "2.3.3"
             },
             "dependencies": {
                 "isarray": {
@@ -1617,13 +1343,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -1632,7 +1358,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -1643,7 +1369,7 @@
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "ark-ts": {
@@ -1651,22 +1377,22 @@
             "resolved": "https://registry.npmjs.org/ark-ts/-/ark-ts-0.3.11.tgz",
             "integrity": "sha512-AxplchcNQN/CVQnUV/G2TgB6nK0ZhxShps+afLLDL/vTUGfWqKooGZjCfahaiIZ9f1ZfHbatfCBF4Y0Natgf+A==",
             "requires": {
-                "@types/bigi": "^1.4.0",
-                "@types/node": "^8.0.12",
-                "@types/request": "^2.0.0",
-                "@types/rx": "^4.1.1",
-                "bigi": "^1.4.2",
-                "bs58check": "^2.0.2",
-                "bytebuffer": "^5.0.1",
-                "create-hash": "^1.1.3",
-                "create-hmac": "^1.1.6",
-                "ecurve": "^1.0.5",
-                "json-typescript-mapper": "^1.1.3",
-                "randombytes": "^2.0.5",
-                "request": "^2.81.0",
-                "rxjs": "^5.4.2",
-                "secp256k1": "^3.3.0",
-                "wif": "^2.0.6"
+                "@types/bigi": "1.4.2",
+                "@types/node": "8.9.4",
+                "@types/request": "2.47.1",
+                "@types/rx": "4.1.1",
+                "bigi": "1.4.2",
+                "bs58check": "2.0.2",
+                "bytebuffer": "5.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ecurve": "1.0.5",
+                "json-typescript-mapper": "1.1.3",
+                "randombytes": "2.0.5",
+                "request": "2.88.0",
+                "rxjs": "5.5.11",
+                "secp256k1": "3.5.0",
+                "wif": "2.0.6"
             },
             "dependencies": {
                 "json-typescript-mapper": {
@@ -1674,31 +1400,30 @@
                     "resolved": "https://registry.npmjs.org/json-typescript-mapper/-/json-typescript-mapper-1.1.3.tgz",
                     "integrity": "sha1-9rH8otA4YR1ltU1/FJ9ijFzwp9o=",
                     "requires": {
-                        "reflect-metadata": "^0.1.3"
+                        "reflect-metadata": "0.1.10"
                     }
                 }
             }
         },
         "arkjs": {
             "version": "github:arkecosystem/ark-js#7a1e7e075b531ab659d53207fc29b0028bc7631a",
-            "from": "github:arkecosystem/ark-js#master",
             "requires": {
-                "bigi": "^1.4.2",
-                "bip66": "^1.1.5",
-                "browserify-bignum": "^1.3.0-2",
-                "bs58check": "^2.0.2",
-                "buffer": "^5.0.8",
-                "bytebuffer": "^5.0.1",
-                "create-hash": "^1.1.3",
-                "create-hmac": "^1.1.6",
-                "crypto-browserify": "^3.12.0",
-                "ecdsa": "^0.7.0",
-                "ecurve": "^1.0.5",
-                "js-nacl": "^1.2.2",
-                "randombytes": "^2.0.5",
-                "secp256k1": "^3.3.0",
-                "typeforce": "^1.11.7",
-                "wif": "^2.0.6"
+                "bigi": "1.4.2",
+                "bip66": "1.1.5",
+                "browserify-bignum": "1.3.0-2",
+                "bs58check": "2.0.2",
+                "buffer": "5.2.1",
+                "bytebuffer": "5.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "crypto-browserify": "3.12.0",
+                "ecdsa": "0.7.0",
+                "ecurve": "1.0.5",
+                "js-nacl": "1.2.2",
+                "randombytes": "2.0.5",
+                "secp256k1": "3.5.0",
+                "typeforce": "1.16.0",
+                "wif": "2.0.6"
             },
             "dependencies": {
                 "buffer": {
@@ -1706,8 +1431,8 @@
                     "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
                     "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4"
+                        "base64-js": "1.2.1",
+                        "ieee754": "1.1.8"
                     }
                 },
                 "crypto-browserify": {
@@ -1715,17 +1440,17 @@
                     "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
                     "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
                     "requires": {
-                        "browserify-cipher": "^1.0.0",
-                        "browserify-sign": "^4.0.0",
-                        "create-ecdh": "^4.0.0",
-                        "create-hash": "^1.1.0",
-                        "create-hmac": "^1.1.0",
-                        "diffie-hellman": "^5.0.0",
-                        "inherits": "^2.0.1",
-                        "pbkdf2": "^3.0.3",
-                        "public-encrypt": "^4.0.0",
-                        "randombytes": "^2.0.0",
-                        "randomfill": "^1.0.3"
+                        "browserify-cipher": "1.0.0",
+                        "browserify-sign": "4.0.4",
+                        "create-ecdh": "4.0.0",
+                        "create-hash": "1.1.3",
+                        "create-hmac": "1.1.6",
+                        "diffie-hellman": "5.0.2",
+                        "inherits": "2.0.3",
+                        "pbkdf2": "3.0.14",
+                        "public-encrypt": "4.0.0",
+                        "randombytes": "2.0.5",
+                        "randomfill": "1.0.4"
                     }
                 }
             }
@@ -1735,7 +1460,7 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "requires": {
-                "arr-flatten": "^1.0.1"
+                "arr-flatten": "1.1.0"
             }
         },
         "arr-flatten": {
@@ -1767,8 +1492,8 @@
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.7.0"
+                "define-properties": "1.1.2",
+                "es-abstract": "1.12.0"
             }
         },
         "array-slice": {
@@ -1783,7 +1508,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -1821,7 +1546,7 @@
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "asn1.js": {
@@ -1829,9 +1554,9 @@
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
             "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
             "requires": {
-                "bn.js": "^4.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
             }
         },
         "assert": {
@@ -1860,7 +1585,7 @@
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.14.0"
+                "lodash": "4.17.11"
             }
         },
         "async-each": {
@@ -1897,12 +1622,12 @@
             "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^2.11.3",
-                "caniuse-lite": "^1.0.30000805",
-                "normalize-range": "^0.1.2",
-                "num2fraction": "^1.2.2",
-                "postcss": "^6.0.17",
-                "postcss-value-parser": "^3.2.3"
+                "browserslist": "2.11.3",
+                "caniuse-lite": "1.0.30000893",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "6.0.23",
+                "postcss-value-parser": "3.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1911,7 +1636,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -1920,9 +1645,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -1937,9 +1662,9 @@
                     "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "chalk": "2.4.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "source-map": {
@@ -1954,7 +1679,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -1976,9 +1701,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1993,11 +1718,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "supports-color": {
@@ -2014,14 +1739,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "detect-indent": "^4.0.0",
-                "jsesc": "^1.3.0",
-                "lodash": "^4.17.4",
-                "source-map": "^0.5.7",
-                "trim-right": "^1.0.1"
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             }
         },
         "babel-messages": {
@@ -2030,7 +1755,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-runtime": {
@@ -2039,8 +1764,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "babel-template": {
@@ -2049,11 +1774,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.11"
             }
         },
         "babel-traverse": {
@@ -2062,15 +1787,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.11"
             }
         },
         "babel-types": {
@@ -2079,10 +1804,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "1.0.3"
             }
         },
         "babylon": {
@@ -2108,13 +1833,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "isobject": {
@@ -2130,7 +1855,7 @@
             "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
             "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "base64-arraybuffer": {
@@ -2161,7 +1886,7 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "bcryptjs": {
@@ -2214,13 +1939,13 @@
             "resolved": "https://registry.npmjs.org/bip38/-/bip38-2.0.2.tgz",
             "integrity": "sha512-22KDak0RDyghFbR0Si7wyq9IgY423YzGYzWLpGeofH3DaolOQqjD3mNN08eFoubKlbyclOQKFwtONMv2SD9V3A==",
             "requires": {
-                "bigi": "^1.2.0",
-                "browserify-aes": "^1.0.1",
-                "bs58check": "<3.0.0",
-                "buffer-xor": "^1.0.2",
-                "create-hash": "^1.1.1",
-                "ecurve": "^1.0.0",
-                "scryptsy": "^2.0.0"
+                "bigi": "1.4.2",
+                "browserify-aes": "1.1.1",
+                "bs58check": "2.0.2",
+                "buffer-xor": "1.0.3",
+                "create-hash": "1.1.3",
+                "ecurve": "1.0.5",
+                "scryptsy": "2.0.0"
             }
         },
         "bip39": {
@@ -2228,11 +1953,11 @@
             "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.5.0.tgz",
             "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
             "requires": {
-                "create-hash": "^1.1.0",
-                "pbkdf2": "^3.0.9",
-                "randombytes": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "unorm": "^1.3.3"
+                "create-hash": "1.1.3",
+                "pbkdf2": "3.0.14",
+                "randombytes": "2.0.5",
+                "safe-buffer": "5.1.1",
+                "unorm": "1.4.1"
             }
         },
         "bip66": {
@@ -2240,7 +1965,7 @@
             "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
             "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "blob": {
@@ -2255,7 +1980,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "blocking-proxy": {
@@ -2264,7 +1989,7 @@
             "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
             "dev": true,
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "1.2.0"
             }
         },
         "bluebird": {
@@ -2284,10 +2009,10 @@
             "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
             "dev": true,
             "requires": {
-                "continuable-cache": "^0.3.1",
-                "error": "^7.0.0",
-                "raw-body": "~1.1.0",
-                "safe-json-parse": "~1.0.1"
+                "continuable-cache": "0.3.1",
+                "error": "7.0.2",
+                "raw-body": "1.1.7",
+                "safe-json-parse": "1.0.1"
             },
             "dependencies": {
                 "bytes": {
@@ -2302,8 +2027,8 @@
                     "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
                     "dev": true,
                     "requires": {
-                        "bytes": "1",
-                        "string_decoder": "0.10"
+                        "bytes": "1.0.0",
+                        "string_decoder": "0.10.31"
                     }
                 }
             }
@@ -2315,15 +2040,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.1",
-                "http-errors": "~1.6.2",
+                "depd": "1.1.1",
+                "http-errors": "1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "~1.6.15"
+                "type-is": "1.6.15"
             },
             "dependencies": {
                 "debug": {
@@ -2349,12 +2074,12 @@
             "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
             "dev": true,
             "requires": {
-                "array-flatten": "^2.1.0",
-                "deep-equal": "^1.0.1",
-                "dns-equal": "^1.0.0",
-                "dns-txt": "^2.0.2",
-                "multicast-dns": "^6.0.1",
-                "multicast-dns-service-types": "^1.1.0"
+                "array-flatten": "2.1.1",
+                "deep-equal": "1.0.1",
+                "dns-equal": "1.0.0",
+                "dns-txt": "2.0.2",
+                "multicast-dns": "6.2.3",
+                "multicast-dns-service-types": "1.1.0"
             },
             "dependencies": {
                 "array-flatten": {
@@ -2377,7 +2102,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "bplist-creator": {
@@ -2385,7 +2110,7 @@
             "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
             "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
             "requires": {
-                "stream-buffers": "~2.2.0"
+                "stream-buffers": "2.2.0"
             }
         },
         "bplist-parser": {
@@ -2393,7 +2118,7 @@
             "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
             "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
             "requires": {
-                "big-integer": "^1.6.7"
+                "big-integer": "1.6.25"
             }
         },
         "brace-expansion": {
@@ -2401,7 +2126,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2410,9 +2135,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
             }
         },
         "brorand": {
@@ -2442,12 +2167,12 @@
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
             "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
             "requires": {
-                "buffer-xor": "^1.0.3",
-                "cipher-base": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.3",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
             }
         },
         "browserify-bignum": {
@@ -2460,9 +2185,9 @@
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "requires": {
-                "browserify-aes": "^1.0.4",
-                "browserify-des": "^1.0.0",
-                "evp_bytestokey": "^1.0.0"
+                "browserify-aes": "1.1.1",
+                "browserify-des": "1.0.0",
+                "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
@@ -2470,9 +2195,9 @@
             "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
             "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
             "requires": {
-                "cipher-base": "^1.0.1",
-                "des.js": "^1.0.0",
-                "inherits": "^2.0.1"
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
             }
         },
         "browserify-rsa": {
@@ -2480,8 +2205,8 @@
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "requires": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.5"
             }
         },
         "browserify-sign": {
@@ -2489,13 +2214,13 @@
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "requires": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.0"
             }
         },
         "browserify-zlib": {
@@ -2504,7 +2229,7 @@
             "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
             "dev": true,
             "requires": {
-                "pako": "~0.2.0"
+                "pako": "0.2.9"
             }
         },
         "browserslist": {
@@ -2513,8 +2238,8 @@
             "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000792",
-                "electron-to-chromium": "^1.3.30"
+                "caniuse-lite": "1.0.30000893",
+                "electron-to-chromium": "1.3.80"
             },
             "dependencies": {
                 "electron-to-chromium": {
@@ -2531,7 +2256,7 @@
             "integrity": "sha512-O8VMT64P9NOLhuIoD4YngyxBURefaSdR4QdhG8l6HZ9VxtU7jc3m6jLufFwKA5gaf7fetfB2TnRJnMxyob+heg==",
             "dev": true,
             "requires": {
-                "https-proxy-agent": "^2.2.1"
+                "https-proxy-agent": "2.2.1"
             },
             "dependencies": {
                 "agent-base": {
@@ -2540,7 +2265,7 @@
                     "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
                     "dev": true,
                     "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                     }
                 },
                 "debug": {
@@ -2549,7 +2274,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "https-proxy-agent": {
@@ -2558,8 +2283,8 @@
                     "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
                     "dev": true,
                     "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.2.1",
+                        "debug": "3.2.6"
                     }
                 },
                 "ms": {
@@ -2575,7 +2300,7 @@
             "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
             "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
             "requires": {
-                "base-x": "^3.0.2"
+                "base-x": "3.0.2"
             }
         },
         "bs58check": {
@@ -2583,8 +2308,8 @@
             "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.0.2.tgz",
             "integrity": "sha1-BvY7AcL6YXMDPJDrh/H+PS4T2Jo=",
             "requires": {
-                "bs58": "^4.0.0",
-                "create-hash": "^1.1.0"
+                "bs58": "4.0.1",
+                "create-hash": "1.1.3"
             }
         },
         "buffer": {
@@ -2593,9 +2318,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "base64-js": "1.2.1",
+                "ieee754": "1.1.8",
+                "isarray": "1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -2612,8 +2337,8 @@
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
             "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
+                "buffer-alloc-unsafe": "1.1.0",
+                "buffer-fill": "1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -2661,7 +2386,7 @@
             "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
             "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
             "requires": {
-                "long": "~3"
+                "long": "3.2.0"
             }
         },
         "bytes": {
@@ -2676,19 +2401,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.1.1",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.1",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.1",
+                "y18n": "4.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -2697,12 +2422,12 @@
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "y18n": {
@@ -2719,15 +2444,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -2744,10 +2469,10 @@
             "integrity": "sha512-rsGh4SIYyB9glU+d0OcHwiXHXBoUgDhHZaQ1KAbiXqfz1CDPxtTboh1gPbJ0q2qdO8a9lfcjgC5CJ2Ms32y5bw==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "mkdirp": "^0.5.1",
-                "neo-async": "^2.5.0",
-                "schema-utils": "^0.4.2"
+                "loader-utils": "1.1.0",
+                "mkdirp": "0.5.1",
+                "neo-async": "2.6.0",
+                "schema-utils": "0.4.7"
             }
         },
         "callsite": {
@@ -2762,8 +2487,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "^2.2.0",
-                "upper-case": "^1.1.1"
+                "no-case": "2.3.2",
+                "upper-case": "1.1.3"
             }
         },
         "camelcase": {
@@ -2778,8 +2503,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "^2.0.0",
-                "map-obj": "^1.0.0"
+                "camelcase": "2.1.1",
+                "map-obj": "1.0.1"
             }
         },
         "caniuse-lite": {
@@ -2794,7 +2519,7 @@
             "integrity": "sha1-4/lc7HsWvy1vP8clwC2UDTJY9ps=",
             "optional": true,
             "requires": {
-                "nan": "^2.4.0"
+                "nan": "2.7.0"
             }
         },
         "caseless": {
@@ -2808,8 +2533,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "dev": true,
             "requires": {
-                "align-text": "^0.1.3",
-                "lazy-cache": "^1.0.3"
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
             }
         },
         "chalk": {
@@ -2818,9 +2543,9 @@
             "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.1.0",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^4.0.0"
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.5.0"
             },
             "dependencies": {
                 "has-flag": {
@@ -2835,7 +2560,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                     }
                 }
             }
@@ -2845,8 +2570,8 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.2.tgz",
             "integrity": "sha512-90wl3V9xRZ8tnMvMlpcW+0Yg13BelsGS9P9t0ClaDxv/hdypHDr/YAGf+728m11P5ljwyB0ZHfPKCapZFqSqYA==",
             "requires": {
-                "chartjs-color": "^2.1.0",
-                "moment": "^2.10.2"
+                "chartjs-color": "2.2.0",
+                "moment": "2.22.2"
             }
         },
         "chartjs-color": {
@@ -2854,8 +2579,8 @@
             "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.2.0.tgz",
             "integrity": "sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=",
             "requires": {
-                "chartjs-color-string": "^0.5.0",
-                "color-convert": "^0.5.3"
+                "chartjs-color-string": "0.5.0",
+                "color-convert": "0.5.3"
             },
             "dependencies": {
                 "color-convert": {
@@ -2870,7 +2595,7 @@
             "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz",
             "integrity": "sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==",
             "requires": {
-                "color-name": "^1.0.0"
+                "color-name": "1.1.3"
             }
         },
         "chokidar": {
@@ -2878,15 +2603,15 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "fsevents": "1.2.4",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
             }
         },
         "chownr": {
@@ -2900,8 +2625,8 @@
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
             }
         },
         "circular-dependency-plugin": {
@@ -2922,10 +2647,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -2934,7 +2659,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2943,7 +2668,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2952,7 +2677,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -2963,7 +2688,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2972,7 +2697,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -2983,9 +2708,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
                     }
                 },
                 "isobject": {
@@ -3008,7 +2733,7 @@
             "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
             "dev": true,
             "requires": {
-                "source-map": "~0.6.0"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -3025,9 +2750,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
             }
         },
         "clone": {
@@ -3042,10 +2767,10 @@
             "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
             "dev": true,
             "requires": {
-                "for-own": "^1.0.0",
-                "is-plain-object": "^2.0.4",
-                "kind-of": "^6.0.0",
-                "shallow-clone": "^1.0.0"
+                "for-own": "1.0.0",
+                "is-plain-object": "2.0.4",
+                "kind-of": "6.0.2",
+                "shallow-clone": "1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -3054,7 +2779,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "for-in": "1.0.2"
                     }
                 },
                 "kind-of": {
@@ -3082,8 +2807,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -3092,7 +2817,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -3101,9 +2826,9 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "colors": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+            "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
         },
         "combine-lists": {
             "version": "1.0.1",
@@ -3111,7 +2836,7 @@
             "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
             "dev": true,
             "requires": {
-                "lodash": "^4.5.0"
+                "lodash": "4.17.11"
             }
         },
         "combined-stream": {
@@ -3120,7 +2845,7 @@
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -3129,7 +2854,7 @@
             "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
             "dev": true,
             "requires": {
-                "graceful-readlink": ">= 1.0.0"
+                "graceful-readlink": "1.0.1"
             }
         },
         "common-tags": {
@@ -3174,7 +2899,7 @@
             "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
             "dev": true,
             "requires": {
-                "mime-db": ">= 1.36.0 < 2"
+                "mime-db": "1.37.0"
             },
             "dependencies": {
                 "mime-db": {
@@ -3191,13 +2916,13 @@
             "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.5",
+                "accepts": "1.3.5",
                 "bytes": "3.0.0",
-                "compressible": "~2.0.14",
+                "compressible": "2.0.15",
                 "debug": "2.6.9",
-                "on-headers": "~1.0.1",
+                "on-headers": "1.0.1",
                 "safe-buffer": "5.1.2",
-                "vary": "~1.1.2"
+                "vary": "1.1.2"
             },
             "dependencies": {
                 "accepts": {
@@ -3206,7 +2931,7 @@
                     "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "~2.1.18",
+                        "mime-types": "2.1.21",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -3222,7 +2947,7 @@
                     "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "~1.37.0"
+                        "mime-db": "1.37.0"
                     }
                 },
                 "safe-buffer": {
@@ -3244,10 +2969,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             },
             "dependencies": {
                 "isarray": {
@@ -3268,13 +2993,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -3283,7 +3008,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -3296,7 +3021,7 @@
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
-                "parseurl": "~1.3.2",
+                "parseurl": "1.3.2",
                 "utils-merge": "1.0.1"
             },
             "dependencies": {
@@ -3307,12 +3032,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "~1.0.1",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "statuses": "~1.3.1",
-                        "unpipe": "~1.0.0"
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.3.1",
+                        "unpipe": "1.0.0"
                     }
                 }
             }
@@ -3329,7 +3054,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "^0.1.4"
+                "date-now": "0.1.4"
             }
         },
         "console-control-strings": {
@@ -3368,7 +3093,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "cookie": {
@@ -3389,12 +3114,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "copy-descriptor": {
@@ -3409,14 +3134,14 @@
             "integrity": "sha512-v4THQ24Tks2NkyOvZuFDgZVfDD9YaA9rwYLZTrWg2GHIA8lrH5DboEyeoorh5Skki+PUbgSmnsCwhMWqYrQZrA==",
             "dev": true,
             "requires": {
-                "cacache": "^10.0.1",
-                "find-cache-dir": "^1.0.0",
-                "globby": "^7.1.1",
-                "is-glob": "^4.0.0",
-                "loader-utils": "^1.1.0",
-                "minimatch": "^3.0.4",
-                "p-limit": "^1.0.0",
-                "serialize-javascript": "^1.4.0"
+                "cacache": "10.0.4",
+                "find-cache-dir": "1.0.0",
+                "globby": "7.1.1",
+                "is-glob": "4.0.0",
+                "loader-utils": "1.1.0",
+                "minimatch": "3.0.4",
+                "p-limit": "1.1.0",
+                "serialize-javascript": "1.5.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -3431,7 +3156,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -3446,36 +3171,36 @@
             "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-7.1.1.tgz",
             "integrity": "sha512-MAOwEMT3TuGjKw4McNzzYyHmxkWY3ozafbIgdMAvPzqSBVGIcn+H3SmWfaHtUXfmIPFliT171ICsSm6W5lZXEA==",
             "requires": {
-                "abbrev": "*",
+                "abbrev": "1.1.1",
                 "android-versions": "1.3.0",
-                "ansi": "*",
-                "balanced-match": "*",
+                "ansi": "0.3.1",
+                "balanced-match": "1.0.0",
                 "base64-js": "1.2.0",
-                "big-integer": "*",
-                "bplist-parser": "*",
-                "brace-expansion": "*",
-                "concat-map": "*",
+                "big-integer": "1.6.32",
+                "bplist-parser": "0.1.1",
+                "brace-expansion": "1.1.11",
+                "concat-map": "0.0.1",
                 "cordova-common": "2.2.5",
-                "cordova-registry-mapper": "*",
+                "cordova-registry-mapper": "1.1.15",
                 "elementtree": "0.1.6",
                 "glob": "5.0.15",
-                "inflight": "*",
-                "inherits": "*",
-                "minimatch": "*",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
                 "nopt": "3.0.1",
-                "once": "*",
-                "path-is-absolute": "*",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1",
                 "plist": "2.1.0",
                 "properties-parser": "0.2.3",
                 "q": "1.4.1",
                 "sax": "0.3.5",
-                "semver": "*",
+                "semver": "5.5.0",
                 "shelljs": "0.5.3",
-                "underscore": "*",
-                "unorm": "*",
-                "wrappy": "*",
+                "underscore": "1.9.1",
+                "unorm": "1.4.1",
+                "wrappy": "1.0.2",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "*"
+                "xmldom": "0.1.27"
             },
             "dependencies": {
                 "abbrev": {
@@ -3486,7 +3211,7 @@
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "semver": "^5.4.1"
+                        "semver": "5.5.0"
                     }
                 },
                 "ansi": {
@@ -3509,14 +3234,14 @@
                     "version": "0.1.1",
                     "bundled": true,
                     "requires": {
-                        "big-integer": "^1.6.7"
+                        "big-integer": "1.6.32"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -3528,17 +3253,17 @@
                     "version": "2.2.5",
                     "bundled": true,
                     "requires": {
-                        "ansi": "^0.3.1",
-                        "bplist-parser": "^0.1.0",
-                        "cordova-registry-mapper": "^1.1.8",
+                        "ansi": "0.3.1",
+                        "bplist-parser": "0.1.1",
+                        "cordova-registry-mapper": "1.1.15",
                         "elementtree": "0.1.6",
-                        "glob": "^5.0.13",
-                        "minimatch": "^3.0.0",
-                        "plist": "^2.1.0",
-                        "q": "^1.4.1",
-                        "shelljs": "^0.5.3",
-                        "underscore": "^1.8.3",
-                        "unorm": "^1.3.3"
+                        "glob": "5.0.15",
+                        "minimatch": "3.0.4",
+                        "plist": "2.1.0",
+                        "q": "1.4.1",
+                        "shelljs": "0.5.3",
+                        "underscore": "1.9.1",
+                        "unorm": "1.4.1"
                     }
                 },
                 "cordova-registry-mapper": {
@@ -3556,19 +3281,19 @@
                     "version": "5.0.15",
                     "bundled": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -3579,21 +3304,21 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "nopt": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                     }
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -3606,7 +3331,7 @@
                     "requires": {
                         "base64-js": "1.2.0",
                         "xmlbuilder": "8.2.2",
-                        "xmldom": "0.1.x"
+                        "xmldom": "0.1.27"
                     }
                 },
                 "properties-parser": {
@@ -3656,92 +3381,92 @@
             "resolved": "https://registry.npmjs.org/cordova-browser/-/cordova-browser-5.0.4.tgz",
             "integrity": "sha512-EDuG+9NGsaYpNSY6wF0kR34m1m38V+nRglGXxQ609fgMYrMHEYR2lg38nDr1Os4qeF0LJz8UQ7nq7Y+idg6Aig==",
             "requires": {
-                "abbrev": "*",
-                "accepts": "*",
-                "ansi": "*",
+                "abbrev": "1.1.1",
+                "accepts": "1.3.5",
+                "ansi": "0.3.1",
                 "ansi-regex": "2.1.1",
                 "ansi-styles": "2.2.1",
                 "array-flatten": "1.1.1",
-                "balanced-match": "*",
+                "balanced-match": "1.0.0",
                 "base64-js": "1.2.0",
-                "big-integer": "*",
+                "big-integer": "1.6.32",
                 "body-parser": "1.18.2",
-                "bplist-parser": "*",
-                "brace-expansion": "*",
-                "bytes": "*",
+                "bplist-parser": "0.1.1",
+                "brace-expansion": "1.1.11",
+                "bytes": "3.0.0",
                 "chalk": "1.1.3",
-                "compressible": "*",
+                "compressible": "2.0.14",
                 "compression": "1.7.2",
-                "concat-map": "*",
-                "content-disposition": "*",
-                "content-type": "*",
-                "cookie": "*",
+                "concat-map": "0.0.1",
+                "content-disposition": "0.5.2",
+                "content-type": "1.0.4",
+                "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "cordova-common": "2.2.5",
-                "cordova-registry-mapper": "*",
+                "cordova-registry-mapper": "1.1.15",
                 "cordova-serve": "2.0.1",
                 "debug": "2.6.9",
-                "depd": "*",
-                "destroy": "*",
-                "ee-first": "*",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "ee-first": "1.1.1",
                 "elementtree": "0.1.6",
-                "encodeurl": "*",
-                "escape-html": "*",
-                "escape-string-regexp": "*",
-                "etag": "*",
-                "express": "*",
-                "finalhandler": "*",
-                "forwarded": "*",
-                "fresh": "*",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "escape-string-regexp": "1.0.5",
+                "etag": "1.8.1",
+                "express": "4.16.3",
+                "finalhandler": "1.1.1",
+                "forwarded": "0.1.2",
+                "fresh": "0.5.2",
                 "glob": "5.0.15",
                 "has-ansi": "2.0.0",
                 "http-errors": "1.6.3",
                 "iconv-lite": "0.4.19",
-                "inflight": "*",
-                "inherits": "*",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
                 "ipaddr.js": "1.6.0",
-                "is-wsl": "*",
-                "media-typer": "*",
-                "merge-descriptors": "*",
-                "methods": "*",
+                "is-wsl": "1.1.0",
+                "media-typer": "0.3.0",
+                "merge-descriptors": "1.0.1",
+                "methods": "1.1.2",
                 "mime": "1.4.1",
                 "mime-db": "1.33.0",
                 "mime-types": "2.1.18",
-                "minimatch": "*",
+                "minimatch": "3.0.4",
                 "ms": "2.0.0",
-                "negotiator": "*",
+                "negotiator": "0.6.1",
                 "nopt": "3.0.6",
-                "on-finished": "*",
-                "on-headers": "*",
-                "once": "*",
-                "opn": "*",
-                "parseurl": "*",
-                "path-is-absolute": "*",
+                "on-finished": "2.3.0",
+                "on-headers": "1.0.1",
+                "once": "1.4.0",
+                "opn": "5.3.0",
+                "parseurl": "1.3.2",
+                "path-is-absolute": "1.0.1",
                 "path-to-regexp": "0.1.7",
                 "plist": "2.1.0",
                 "proxy-addr": "2.0.3",
-                "q": "*",
+                "q": "1.5.1",
                 "qs": "6.5.1",
-                "range-parser": "*",
+                "range-parser": "1.2.0",
                 "raw-body": "2.3.2",
                 "safe-buffer": "5.1.1",
                 "sax": "0.3.5",
-                "send": "*",
-                "serve-static": "*",
-                "setprototypeof": "*",
+                "send": "0.16.2",
+                "serve-static": "1.13.2",
+                "setprototypeof": "1.1.0",
                 "shelljs": "0.5.3",
                 "statuses": "1.4.0",
                 "strip-ansi": "3.0.1",
                 "supports-color": "2.0.0",
-                "type-is": "*",
-                "underscore": "*",
-                "unorm": "*",
-                "unpipe": "*",
-                "utils-merge": "*",
-                "vary": "*",
-                "wrappy": "*",
+                "type-is": "1.6.16",
+                "underscore": "1.9.1",
+                "unorm": "1.4.1",
+                "unpipe": "1.0.0",
+                "utils-merge": "1.0.1",
+                "vary": "1.1.2",
+                "wrappy": "1.0.2",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "*"
+                "xmldom": "0.1.27"
             },
             "dependencies": {
                 "abbrev": {
@@ -3752,7 +3477,7 @@
                     "version": "1.3.5",
                     "bundled": true,
                     "requires": {
-                        "mime-types": "~2.1.18",
+                        "mime-types": "2.1.18",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -3789,29 +3514,29 @@
                     "bundled": true,
                     "requires": {
                         "bytes": "3.0.0",
-                        "content-type": "~1.0.4",
+                        "content-type": "1.0.4",
                         "debug": "2.6.9",
-                        "depd": "~1.1.1",
-                        "http-errors": "~1.6.2",
+                        "depd": "1.1.2",
+                        "http-errors": "1.6.3",
                         "iconv-lite": "0.4.19",
-                        "on-finished": "~2.3.0",
+                        "on-finished": "2.3.0",
                         "qs": "6.5.1",
                         "raw-body": "2.3.2",
-                        "type-is": "~1.6.15"
+                        "type-is": "1.6.16"
                     }
                 },
                 "bplist-parser": {
                     "version": "0.1.1",
                     "bundled": true,
                     "requires": {
-                        "big-integer": "^1.6.7"
+                        "big-integer": "1.6.32"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -3823,18 +3548,18 @@
                     "version": "1.1.3",
                     "bundled": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "compressible": {
                     "version": "2.0.14",
                     "bundled": true,
                     "requires": {
-                        "mime-db": ">= 1.34.0 < 2"
+                        "mime-db": "1.34.0"
                     },
                     "dependencies": {
                         "mime-db": {
@@ -3847,13 +3572,13 @@
                     "version": "1.7.2",
                     "bundled": true,
                     "requires": {
-                        "accepts": "~1.3.4",
+                        "accepts": "1.3.5",
                         "bytes": "3.0.0",
-                        "compressible": "~2.0.13",
+                        "compressible": "2.0.14",
                         "debug": "2.6.9",
-                        "on-headers": "~1.0.1",
+                        "on-headers": "1.0.1",
                         "safe-buffer": "5.1.1",
-                        "vary": "~1.1.2"
+                        "vary": "1.1.2"
                     }
                 },
                 "concat-map": {
@@ -3880,17 +3605,17 @@
                     "version": "2.2.5",
                     "bundled": true,
                     "requires": {
-                        "ansi": "^0.3.1",
-                        "bplist-parser": "^0.1.0",
-                        "cordova-registry-mapper": "^1.1.8",
+                        "ansi": "0.3.1",
+                        "bplist-parser": "0.1.1",
+                        "cordova-registry-mapper": "1.1.15",
                         "elementtree": "0.1.6",
-                        "glob": "^5.0.13",
-                        "minimatch": "^3.0.0",
-                        "plist": "^2.1.0",
-                        "q": "^1.4.1",
-                        "shelljs": "^0.5.3",
-                        "underscore": "^1.8.3",
-                        "unorm": "^1.3.3"
+                        "glob": "5.0.15",
+                        "minimatch": "3.0.4",
+                        "plist": "2.1.0",
+                        "q": "1.5.1",
+                        "shelljs": "0.5.3",
+                        "underscore": "1.9.1",
+                        "unorm": "1.4.1"
                     }
                 },
                 "cordova-registry-mapper": {
@@ -3901,11 +3626,11 @@
                     "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "chalk": "^1.1.1",
-                        "compression": "^1.6.0",
-                        "express": "^4.13.3",
-                        "opn": "^5.3.0",
-                        "shelljs": "^0.5.3"
+                        "chalk": "1.1.3",
+                        "compression": "1.7.2",
+                        "express": "4.16.3",
+                        "opn": "5.3.0",
+                        "shelljs": "0.5.3"
                     }
                 },
                 "debug": {
@@ -3954,36 +3679,36 @@
                     "version": "4.16.3",
                     "bundled": true,
                     "requires": {
-                        "accepts": "~1.3.5",
+                        "accepts": "1.3.5",
                         "array-flatten": "1.1.1",
                         "body-parser": "1.18.2",
                         "content-disposition": "0.5.2",
-                        "content-type": "~1.0.4",
+                        "content-type": "1.0.4",
                         "cookie": "0.3.1",
                         "cookie-signature": "1.0.6",
                         "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
+                        "depd": "1.1.2",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
                         "finalhandler": "1.1.1",
                         "fresh": "0.5.2",
                         "merge-descriptors": "1.0.1",
-                        "methods": "~1.1.2",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
+                        "methods": "1.1.2",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
                         "path-to-regexp": "0.1.7",
-                        "proxy-addr": "~2.0.3",
+                        "proxy-addr": "2.0.3",
                         "qs": "6.5.1",
-                        "range-parser": "~1.2.0",
+                        "range-parser": "1.2.0",
                         "safe-buffer": "5.1.1",
                         "send": "0.16.2",
                         "serve-static": "1.13.2",
                         "setprototypeof": "1.1.0",
-                        "statuses": "~1.4.0",
-                        "type-is": "~1.6.16",
+                        "statuses": "1.4.0",
+                        "type-is": "1.6.16",
                         "utils-merge": "1.0.1",
-                        "vary": "~1.1.2"
+                        "vary": "1.1.2"
                     }
                 },
                 "finalhandler": {
@@ -3991,12 +3716,12 @@
                     "bundled": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "statuses": "~1.4.0",
-                        "unpipe": "~1.0.0"
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.4.0",
+                        "unpipe": "1.0.0"
                     }
                 },
                 "forwarded": {
@@ -4011,28 +3736,28 @@
                     "version": "5.0.15",
                     "bundled": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-ansi": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "http-errors": {
                     "version": "1.6.3",
                     "bundled": true,
                     "requires": {
-                        "depd": "~1.1.2",
+                        "depd": "1.1.2",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.1.0",
-                        "statuses": ">= 1.4.0 < 2"
+                        "statuses": "1.4.0"
                     }
                 },
                 "iconv-lite": {
@@ -4043,8 +3768,8 @@
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -4083,14 +3808,14 @@
                     "version": "2.1.18",
                     "bundled": true,
                     "requires": {
-                        "mime-db": "~1.33.0"
+                        "mime-db": "1.33.0"
                     }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "ms": {
@@ -4105,7 +3830,7 @@
                     "version": "3.0.6",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                     }
                 },
                 "on-finished": {
@@ -4123,14 +3848,14 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "opn": {
                     "version": "5.3.0",
                     "bundled": true,
                     "requires": {
-                        "is-wsl": "^1.1.0"
+                        "is-wsl": "1.1.0"
                     }
                 },
                 "parseurl": {
@@ -4151,14 +3876,14 @@
                     "requires": {
                         "base64-js": "1.2.0",
                         "xmlbuilder": "8.2.2",
-                        "xmldom": "0.1.x"
+                        "xmldom": "0.1.27"
                     }
                 },
                 "proxy-addr": {
                     "version": "2.0.3",
                     "bundled": true,
                     "requires": {
-                        "forwarded": "~0.1.2",
+                        "forwarded": "0.1.2",
                         "ipaddr.js": "1.6.0"
                     }
                 },
@@ -4195,7 +3920,7 @@
                                 "depd": "1.1.1",
                                 "inherits": "2.0.3",
                                 "setprototypeof": "1.0.3",
-                                "statuses": ">= 1.3.1 < 2"
+                                "statuses": "1.4.0"
                             }
                         },
                         "setprototypeof": {
@@ -4217,27 +3942,27 @@
                     "bundled": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "destroy": "~1.0.4",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
+                        "depd": "1.1.2",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
                         "fresh": "0.5.2",
-                        "http-errors": "~1.6.2",
+                        "http-errors": "1.6.3",
                         "mime": "1.4.1",
                         "ms": "2.0.0",
-                        "on-finished": "~2.3.0",
-                        "range-parser": "~1.2.0",
-                        "statuses": "~1.4.0"
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.4.0"
                     }
                 },
                 "serve-static": {
                     "version": "1.13.2",
                     "bundled": true,
                     "requires": {
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "parseurl": "~1.3.2",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "parseurl": "1.3.2",
                         "send": "0.16.2"
                     }
                 },
@@ -4257,7 +3982,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "supports-color": {
@@ -4269,7 +3994,7 @@
                     "bundled": true,
                     "requires": {
                         "media-typer": "0.3.0",
-                        "mime-types": "~2.1.18"
+                        "mime-types": "2.1.18"
                     }
                 },
                 "underscore": {
@@ -4316,13 +4041,13 @@
             "resolved": "https://registry.npmjs.org/cordova-custom-config/-/cordova-custom-config-5.0.2.tgz",
             "integrity": "sha512-BOlDpmll+CIL+pSFfYrp0ederNCDKvB3X8tDY2EacEvcar/kB2MKs9M5Htv4VTrkfdIbjJtoePD2vaH3apY1Tg==",
             "requires": {
-                "colors": "^1.1.2",
-                "elementtree": "^0.1.6",
-                "lodash": "^4.3.0",
+                "colors": "1.3.2",
+                "elementtree": "0.1.7",
+                "lodash": "4.17.11",
                 "plist": "github:xiangpingmeng/plist.js#5ccd600b0b7fd3ae204edc9e69c1c30406d07747",
-                "shelljs": "^0.7.0",
-                "tostr": "^0.1.0",
-                "xcode": "^1.0.0"
+                "shelljs": "0.7.8",
+                "tostr": "0.1.0",
+                "xcode": "1.0.0"
             },
             "dependencies": {
                 "base64-js": {
@@ -4332,12 +4057,11 @@
                 },
                 "plist": {
                     "version": "github:xiangpingmeng/plist.js#5ccd600b0b7fd3ae204edc9e69c1c30406d07747",
-                    "from": "github:xiangpingmeng/plist.js",
                     "requires": {
                         "base64-js": "0.0.8",
                         "util-deprecate": "1.0.2",
                         "xmlbuilder": "4.0.0",
-                        "xmldom": "0.1.x"
+                        "xmldom": "0.1.27"
                     }
                 },
                 "xmlbuilder": {
@@ -4345,7 +4069,7 @@
                     "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.0.0.tgz",
                     "integrity": "sha1-mLj2UcowqmJANvEn0RzGbce5B6M=",
                     "requires": {
-                        "lodash": "^3.5.0"
+                        "lodash": "3.10.1"
                     },
                     "dependencies": {
                         "lodash": {
@@ -4362,42 +4086,42 @@
             "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-4.5.5.tgz",
             "integrity": "sha512-3+30m2dZ2yii7kg+H7cgpdpkXpMj54zoX5imjGGG4Z7dPXKmalTLc/9rLq+Iaa+Q1BqyOrUFaHopWOODRU6vCg==",
             "requires": {
-                "abbrev": "*",
-                "ansi": "*",
-                "balanced-match": "*",
+                "abbrev": "1.1.1",
+                "ansi": "0.3.1",
+                "balanced-match": "1.0.0",
                 "base64-js": "1.2.0",
-                "big-integer": "*",
-                "bplist-creator": "*",
-                "bplist-parser": "*",
-                "brace-expansion": "*",
-                "concat-map": "*",
+                "big-integer": "1.6.32",
+                "bplist-creator": "0.0.7",
+                "bplist-parser": "0.1.1",
+                "brace-expansion": "1.1.11",
+                "concat-map": "0.0.1",
                 "cordova-common": "2.2.5",
-                "cordova-registry-mapper": "*",
+                "cordova-registry-mapper": "1.1.15",
                 "elementtree": "0.1.6",
                 "glob": "5.0.15",
-                "inflight": "*",
-                "inherits": "*",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
                 "ios-sim": "6.1.3",
-                "minimatch": "*",
+                "minimatch": "3.0.4",
                 "nopt": "3.0.6",
-                "once": "*",
-                "path-is-absolute": "*",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1",
                 "plist": "2.1.0",
                 "q": "1.5.1",
                 "sax": "0.3.5",
                 "shelljs": "0.5.3",
-                "simctl": "*",
+                "simctl": "1.1.1",
                 "simple-plist": "0.2.1",
                 "stream-buffers": "2.2.0",
                 "tail": "0.4.0",
-                "underscore": "*",
-                "unorm": "*",
+                "underscore": "1.9.1",
+                "unorm": "1.4.1",
                 "uuid": "3.0.1",
-                "wrappy": "*",
+                "wrappy": "1.0.2",
                 "xcode": "0.9.3",
                 "xml-escape": "1.1.0",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "*"
+                "xmldom": "0.1.27"
             },
             "dependencies": {
                 "abbrev": {
@@ -4424,21 +4148,21 @@
                     "version": "0.0.7",
                     "bundled": true,
                     "requires": {
-                        "stream-buffers": "~2.2.0"
+                        "stream-buffers": "2.2.0"
                     }
                 },
                 "bplist-parser": {
                     "version": "0.1.1",
                     "bundled": true,
                     "requires": {
-                        "big-integer": "^1.6.7"
+                        "big-integer": "1.6.32"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -4450,17 +4174,17 @@
                     "version": "2.2.5",
                     "bundled": true,
                     "requires": {
-                        "ansi": "^0.3.1",
-                        "bplist-parser": "^0.1.0",
-                        "cordova-registry-mapper": "^1.1.8",
+                        "ansi": "0.3.1",
+                        "bplist-parser": "0.1.1",
+                        "cordova-registry-mapper": "1.1.15",
                         "elementtree": "0.1.6",
-                        "glob": "^5.0.13",
-                        "minimatch": "^3.0.0",
-                        "plist": "^2.1.0",
-                        "q": "^1.4.1",
-                        "shelljs": "^0.5.3",
-                        "underscore": "^1.8.3",
-                        "unorm": "^1.3.3"
+                        "glob": "5.0.15",
+                        "minimatch": "3.0.4",
+                        "plist": "2.1.0",
+                        "q": "1.5.1",
+                        "shelljs": "0.5.3",
+                        "underscore": "1.9.1",
+                        "unorm": "1.4.1"
                     }
                 },
                 "cordova-registry-mapper": {
@@ -4478,19 +4202,19 @@
                     "version": "5.0.15",
                     "bundled": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -4501,10 +4225,10 @@
                     "version": "6.1.3",
                     "bundled": true,
                     "requires": {
-                        "bplist-parser": "^0.0.6",
+                        "bplist-parser": "0.0.6",
                         "nopt": "1.0.9",
-                        "plist": "^2.1.0",
-                        "simctl": "^1.1.1"
+                        "plist": "2.1.0",
+                        "simctl": "1.1.1"
                     },
                     "dependencies": {
                         "bplist-parser": {
@@ -4515,7 +4239,7 @@
                             "version": "1.0.9",
                             "bundled": true,
                             "requires": {
-                                "abbrev": "1"
+                                "abbrev": "1.1.1"
                             }
                         }
                     }
@@ -4524,21 +4248,21 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "nopt": {
                     "version": "3.0.6",
                     "bundled": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                     }
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -4551,7 +4275,7 @@
                     "requires": {
                         "base64-js": "1.2.0",
                         "xmlbuilder": "8.2.2",
-                        "xmldom": "0.1.x"
+                        "xmldom": "0.1.27"
                     }
                 },
                 "q": {
@@ -4570,8 +4294,8 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "shelljs": "^0.2.6",
-                        "tail": "^0.4.0"
+                        "shelljs": "0.2.6",
+                        "tail": "0.4.0"
                     },
                     "dependencies": {
                         "shelljs": {
@@ -4599,7 +4323,7 @@
                             "requires": {
                                 "base64-js": "1.1.2",
                                 "xmlbuilder": "8.2.2",
-                                "xmldom": "0.1.x"
+                                "xmldom": "0.1.27"
                             }
                         }
                     }
@@ -4632,8 +4356,8 @@
                     "version": "0.9.3",
                     "bundled": true,
                     "requires": {
-                        "pegjs": "^0.10.0",
-                        "simple-plist": "^0.2.1",
+                        "pegjs": "0.10.0",
+                        "simple-plist": "0.2.1",
                         "uuid": "3.0.1"
                     }
                 },
@@ -4657,8 +4381,7 @@
             "integrity": "sha512-4syQ0srjXvlH07sAxQlwMAAqIRTI28IWLYI44RFAKFRdYoIyopjQDqUWdieBK2ELvxgffkn6Rr0r0hMdRyGz/w=="
         },
         "cordova-plugin-background-mode": {
-            "version": "git+https://github.com/tushe/cordova-plugin-background-mode.git#9cbe65e7da02c36b0de7039597f5b9a472edd19e",
-            "from": "git+https://github.com/tushe/cordova-plugin-background-mode.git"
+            "version": "git+https://github.com/tushe/cordova-plugin-background-mode.git#9cbe65e7da02c36b0de7039597f5b9a472edd19e"
         },
         "cordova-plugin-badge": {
             "version": "0.8.7",
@@ -4690,11 +4413,6 @@
             "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-keyboard/-/cordova-plugin-ionic-keyboard-2.1.3.tgz",
             "integrity": "sha512-6ucQ6FdlLdBm8kJfFnzozmBTjru/0xekHP/dAhjoCZggkGRlgs8TsUJFkxa/bV+qi7Dlo50JjmpE4UMWAO+aOQ=="
         },
-        "cordova-plugin-ionic-webview": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-2.2.0.tgz",
-            "integrity": "sha512-mNTJaIRsz83Vntk2d3jrPCnlqEPQsfOJW6U2AzS7WV1T15Jj/STdXI/Uv1vIyvPVd9h1OLF+yu64ZsmQH2VRMQ=="
-        },
         "cordova-plugin-local-notification": {
             "version": "0.9.0-beta.2",
             "resolved": "https://registry.npmjs.org/cordova-plugin-local-notification/-/cordova-plugin-local-notification-0.9.0-beta.2.tgz",
@@ -4710,8 +4428,8 @@
             "resolved": "https://registry.npmjs.org/cordova-plugin-qrscanner/-/cordova-plugin-qrscanner-2.6.0.tgz",
             "integrity": "sha512-bgy+cG0HdpuSW/JxHDFQYaO46Ma8nYTjwduhhWhMmuYeljozqQ4RJcwhJQaxHnjuDi3XDz+rHkszOEOhlSG23w==",
             "requires": {
-                "qrcode-reader": "^1.0.4",
-                "webrtc-adapter": "^3.1.4"
+                "qrcode-reader": "1.0.4",
+                "webrtc-adapter": "3.4.3"
             }
         },
         "cordova-plugin-screen-orientation": {
@@ -4734,7 +4452,7 @@
             "resolved": "https://registry.npmjs.org/cordova-plugin-swift-support/-/cordova-plugin-swift-support-3.1.1.tgz",
             "integrity": "sha1-DuWAaPtlBmoBJkgO+a86RhjGsME=",
             "requires": {
-                "xcode": "^0.9.1"
+                "xcode": "0.9.3"
             },
             "dependencies": {
                 "uuid": {
@@ -4747,8 +4465,8 @@
                     "resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
                     "integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
                     "requires": {
-                        "pegjs": "^0.10.0",
-                        "simple-plist": "^0.2.1",
+                        "pegjs": "0.10.0",
+                        "simple-plist": "0.2.1",
                         "uuid": "3.0.1"
                     }
                 }
@@ -4770,9 +4488,9 @@
             "integrity": "sha512-JZcSf0heLKivlaYwmJ/n72Y049wD5FA10yfsJUeOZZpRvGtytnSQtTz0LyT4mGzEDiLUm5WD9k3082Ec4PlaGg=="
         },
         "cordova-sqlite-storage": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/cordova-sqlite-storage/-/cordova-sqlite-storage-2.5.0.tgz",
-            "integrity": "sha512-697fgNS/ZCTXAvV6I/KpKWl4aSoDfI8MYMGTbJYQg+ztwd3dV4sF3PaWmw9Fr1H0iULpIZE64znTvAt/Atsf9Q==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/cordova-sqlite-storage/-/cordova-sqlite-storage-2.5.1.tgz",
+            "integrity": "sha512-RMZcheSs9ihxcXUEmcAg8inG0UHZ5rQKQZqLY40jFES8rpiH5/sYeqaTmnuATx5w2apGB7fFLQHWMG2qaxAVtw==",
             "requires": {
                 "cordova-sqlite-storage-dependencies": "1.2.0"
             }
@@ -4794,7 +4512,7 @@
             "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0"
+                "chalk": "2.3.0"
             }
         },
         "core-util-is": {
@@ -4808,10 +4526,10 @@
             "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
             "dev": true,
             "requires": {
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.9.0",
-                "parse-json": "^4.0.0",
-                "require-from-string": "^2.0.1"
+                "is-directory": "0.3.1",
+                "js-yaml": "3.12.0",
+                "parse-json": "4.0.0",
+                "require-from-string": "2.0.2"
             },
             "dependencies": {
                 "esprima": {
@@ -4826,8 +4544,8 @@
                     "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
                     "dev": true,
                     "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
+                        "argparse": "1.0.9",
+                        "esprima": "4.0.1"
                     }
                 },
                 "parse-json": {
@@ -4836,8 +4554,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.1",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 }
             }
@@ -4847,8 +4565,8 @@
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
             "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
             "requires": {
-                "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
             }
         },
         "create-hash": {
@@ -4856,10 +4574,10 @@
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
             "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "sha.js": "2.4.9"
             }
         },
         "create-hmac": {
@@ -4867,12 +4585,12 @@
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
             "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.9"
             }
         },
         "cross-spawn": {
@@ -4881,9 +4599,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
             }
         },
         "cryptiles": {
@@ -4892,7 +4610,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.x.x"
+                "boom": "2.10.1"
             }
         },
         "crypto-browserify": {
@@ -4901,16 +4619,16 @@
             "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
             "dev": true,
             "requires": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "browserify-cipher": "1.0.0",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.0",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "diffie-hellman": "5.0.2",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.14",
+                "public-encrypt": "4.0.0",
+                "randombytes": "2.0.5"
             }
         },
         "css-parse": {
@@ -4925,10 +4643,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0",
-                "css-what": "2.1",
+                "boolbase": "1.0.0",
+                "css-what": "2.1.0",
                 "domutils": "1.5.1",
-                "nth-check": "~1.0.1"
+                "nth-check": "1.0.1"
             }
         },
         "css-what": {
@@ -4949,7 +4667,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "^1.0.1"
+                "array-find-index": "1.0.2"
             }
         },
         "custom-event": {
@@ -4970,7 +4688,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.9"
+                "es5-ext": "0.10.35"
             }
         },
         "dashdash": {
@@ -4978,7 +4696,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "date-format": {
@@ -5026,7 +4744,7 @@
             "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
             "dev": true,
             "requires": {
-                "strip-bom": "^3.0.0"
+                "strip-bom": "3.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -5043,8 +4761,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "^2.0.5",
-                "object-keys": "^1.0.8"
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
             }
         },
         "define-property": {
@@ -5053,7 +4771,7 @@
             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
             }
         },
         "del": {
@@ -5062,12 +4780,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "^6.1.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "p-map": "^1.1.1",
-                "pify": "^3.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "6.1.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "p-map": "1.2.0",
+                "pify": "3.0.0",
+                "rimraf": "2.6.2"
             },
             "dependencies": {
                 "globby": {
@@ -5076,11 +4794,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "^1.0.1",
-                        "glob": "^7.0.3",
-                        "object-assign": "^4.0.1",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "array-union": "1.0.2",
+                        "glob": "7.1.3",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                     },
                     "dependencies": {
                         "pify": {
@@ -5127,8 +4845,8 @@
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "requires": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
             }
         },
         "destroy": {
@@ -5143,7 +4861,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "detect-node": {
@@ -5169,9 +4887,9 @@
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
             "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
             "requires": {
-                "bn.js": "^4.1.0",
-                "miller-rabin": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.5"
             }
         },
         "dir-glob": {
@@ -5180,8 +4898,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "path-type": "^3.0.0"
+                "arrify": "1.0.1",
+                "path-type": "3.0.0"
             },
             "dependencies": {
                 "path-type": {
@@ -5190,7 +4908,7 @@
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -5213,8 +4931,8 @@
             "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
             "dev": true,
             "requires": {
-                "ip": "^1.1.0",
-                "safe-buffer": "^5.0.1"
+                "ip": "1.1.5",
+                "safe-buffer": "5.1.1"
             }
         },
         "dns-txt": {
@@ -5223,7 +4941,7 @@
             "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
             "dev": true,
             "requires": {
-                "buffer-indexof": "^1.0.0"
+                "buffer-indexof": "1.1.1"
             }
         },
         "doctrine": {
@@ -5232,7 +4950,7 @@
             "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
             "dev": true,
             "requires": {
-                "esutils": "^1.1.6",
+                "esutils": "1.1.6",
                 "isarray": "0.0.1"
             },
             "dependencies": {
@@ -5250,7 +4968,7 @@
             "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
             "dev": true,
             "requires": {
-                "utila": "~0.4"
+                "utila": "0.4.0"
             }
         },
         "dom-serialize": {
@@ -5259,10 +4977,10 @@
             "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
             "dev": true,
             "requires": {
-                "custom-event": "~1.0.0",
-                "ent": "~2.2.0",
-                "extend": "^3.0.0",
-                "void-elements": "^2.0.0"
+                "custom-event": "1.0.1",
+                "ent": "2.2.0",
+                "extend": "3.0.1",
+                "void-elements": "2.0.1"
             }
         },
         "dom-serializer": {
@@ -5271,8 +4989,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -5301,7 +5019,7 @@
             "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
             "dev": true,
             "requires": {
-                "domelementtype": "1"
+                "domelementtype": "1.3.0"
             }
         },
         "domutils": {
@@ -5310,8 +5028,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
             }
         },
         "dotenv": {
@@ -5326,7 +5044,7 @@
             "integrity": "sha1-xEOVqyHR/SjXmpCUKnsUsd69FF8=",
             "dev": true,
             "requires": {
-                "dotenv": "^5.0.1"
+                "dotenv": "5.0.1"
             }
         },
         "drbg.js": {
@@ -5334,9 +5052,9 @@
             "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
             "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
             "requires": {
-                "browserify-aes": "^1.0.6",
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4"
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6"
             }
         },
         "duplexify": {
@@ -5345,10 +5063,10 @@
             "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -5369,13 +5087,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -5384,7 +5102,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -5394,8 +5112,8 @@
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "ecdsa": {
@@ -5403,11 +5121,11 @@
             "resolved": "https://registry.npmjs.org/ecdsa/-/ecdsa-0.7.0.tgz",
             "integrity": "sha1-9lziMAInsWKBApArK5NgfIBt4dk=",
             "requires": {
-                "bigi": "^1.2.1",
-                "bip66": "^1.1.0",
-                "create-hmac": "^1.1.4",
-                "ecurve": "^1.0.0",
-                "typeforce": "^1.6.1"
+                "bigi": "1.4.2",
+                "bip66": "1.1.5",
+                "create-hmac": "1.1.6",
+                "ecurve": "1.0.5",
+                "typeforce": "1.16.0"
             }
         },
         "ecurve": {
@@ -5415,7 +5133,7 @@
             "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.5.tgz",
             "integrity": "sha1-0Ujo/lCmdPmDu1uuCdoOoj4QU14=",
             "requires": {
-                "bigi": "^1.1.0"
+                "bigi": "1.4.2"
             }
         },
         "ee-first": {
@@ -5450,13 +5168,13 @@
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "ember-cli-string-utils": {
@@ -5483,7 +5201,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "engine.io": {
@@ -5492,12 +5210,12 @@
             "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.4",
+                "accepts": "1.3.4",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.0",
-                "ws": "~3.3.1"
+                "debug": "3.1.0",
+                "engine.io-parser": "2.1.2",
+                "ws": "3.3.3"
             },
             "dependencies": {
                 "debug": {
@@ -5519,14 +5237,14 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.1",
+                "debug": "3.1.0",
+                "engine.io-parser": "2.1.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "~3.3.1",
-                "xmlhttprequest-ssl": "~1.5.4",
+                "ws": "3.3.3",
+                "xmlhttprequest-ssl": "1.5.5",
                 "yeast": "0.1.2"
             },
             "dependencies": {
@@ -5548,10 +5266,10 @@
             "dev": true,
             "requires": {
                 "after": "0.8.2",
-                "arraybuffer.slice": "~0.0.7",
+                "arraybuffer.slice": "0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.4",
-                "has-binary2": "~1.0.2"
+                "has-binary2": "1.0.3"
             }
         },
         "enhanced-resolve": {
@@ -5560,10 +5278,10 @@
             "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "object-assign": "^4.0.1",
-                "tapable": "^0.2.7"
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "object-assign": "4.1.1",
+                "tapable": "0.2.8"
             }
         },
         "ent": {
@@ -5584,7 +5302,7 @@
             "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
             "dev": true,
             "requires": {
-                "prr": "~0.0.0"
+                "prr": "0.0.0"
             }
         },
         "error": {
@@ -5593,8 +5311,8 @@
             "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
             "dev": true,
             "requires": {
-                "string-template": "~0.2.1",
-                "xtend": "~4.0.0"
+                "string-template": "0.2.1",
+                "xtend": "4.0.1"
             }
         },
         "error-ex": {
@@ -5603,7 +5321,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "es-abstract": {
@@ -5612,11 +5330,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.1.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4"
             }
         },
         "es-to-primitive": {
@@ -5625,9 +5343,9 @@
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
             }
         },
         "es5-ext": {
@@ -5636,8 +5354,8 @@
             "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
             "dev": true,
             "requires": {
-                "es6-iterator": "~2.0.1",
-                "es6-symbol": "~3.1.1"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
             }
         },
         "es6-iterator": {
@@ -5646,9 +5364,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-symbol": "3.1.1"
             }
         },
         "es6-map": {
@@ -5657,12 +5375,12 @@
             "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14",
-                "es6-iterator": "~2.0.1",
-                "es6-set": "~0.1.5",
-                "es6-symbol": "~3.1.1",
-                "event-emitter": "~0.3.5"
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
             }
         },
         "es6-promise-plugin": {
@@ -5676,7 +5394,7 @@
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
-                "es6-promise": "^4.0.3"
+                "es6-promise": "4.2.5"
             },
             "dependencies": {
                 "es6-promise": {
@@ -5693,11 +5411,11 @@
             "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14",
-                "es6-iterator": "~2.0.1",
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-iterator": "2.0.3",
                 "es6-symbol": "3.1.1",
-                "event-emitter": "~0.3.5"
+                "event-emitter": "0.3.5"
             }
         },
         "es6-symbol": {
@@ -5706,8 +5424,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.35"
             }
         },
         "es6-weak-map": {
@@ -5716,10 +5434,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.35",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
             }
         },
         "escape-html": {
@@ -5740,10 +5458,10 @@
             "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
             "dev": true,
             "requires": {
-                "es6-map": "^0.1.3",
-                "es6-weak-map": "^2.0.1",
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
             }
         },
         "esrecurse": {
@@ -5752,8 +5470,8 @@
             "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0",
-                "object-assign": "^4.0.1"
+                "estraverse": "4.2.0",
+                "object-assign": "4.1.1"
             }
         },
         "estraverse": {
@@ -5786,8 +5504,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.35"
             }
         },
         "eventemitter3": {
@@ -5808,7 +5526,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": ">=0.0.5"
+                "original": "1.0.2"
             }
         },
         "evp_bytestokey": {
@@ -5816,8 +5534,8 @@
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "requires": {
-                "md5.js": "^1.3.4",
-                "safe-buffer": "^5.1.1"
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
             }
         },
         "execa": {
@@ -5826,13 +5544,13 @@
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             }
         },
         "exit": {
@@ -5847,9 +5565,9 @@
             "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
             "dev": true,
             "requires": {
-                "array-slice": "^0.2.3",
-                "array-unique": "^0.2.1",
-                "braces": "^0.1.2"
+                "array-slice": "0.2.3",
+                "array-unique": "0.2.1",
+                "braces": "0.1.5"
             },
             "dependencies": {
                 "braces": {
@@ -5858,7 +5576,7 @@
                     "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "^0.1.0"
+                        "expand-range": "0.1.1"
                     }
                 },
                 "expand-range": {
@@ -5867,8 +5585,8 @@
                     "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
                     "dev": true,
                     "requires": {
-                        "is-number": "^0.1.1",
-                        "repeat-string": "^0.2.2"
+                        "is-number": "0.1.1",
+                        "repeat-string": "0.2.2"
                     }
                 },
                 "is-number": {
@@ -5890,7 +5608,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
             }
         },
         "expand-range": {
@@ -5898,7 +5616,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             }
         },
         "express": {
@@ -5907,36 +5625,36 @@
             "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.5",
+                "accepts": "1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.4",
+                "proxy-addr": "2.0.4",
                 "qs": "6.5.2",
-                "range-parser": "~1.2.0",
+                "range-parser": "1.2.0",
                 "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "~1.4.0",
-                "type-is": "~1.6.16",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "vary": "1.1.2"
             },
             "dependencies": {
                 "accepts": {
@@ -5945,7 +5663,7 @@
                     "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "~2.1.18",
+                        "mime-types": "2.1.21",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -5956,15 +5674,15 @@
                     "dev": true,
                     "requires": {
                         "bytes": "3.0.0",
-                        "content-type": "~1.0.4",
+                        "content-type": "1.0.4",
                         "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "http-errors": "~1.6.3",
+                        "depd": "1.1.2",
+                        "http-errors": "1.6.3",
                         "iconv-lite": "0.4.23",
-                        "on-finished": "~2.3.0",
+                        "on-finished": "2.3.0",
                         "qs": "6.5.2",
                         "raw-body": "2.3.3",
-                        "type-is": "~1.6.16"
+                        "type-is": "1.6.16"
                     }
                 },
                 "depd": {
@@ -5985,10 +5703,10 @@
                     "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
                     "dev": true,
                     "requires": {
-                        "depd": "~1.1.2",
+                        "depd": "1.1.2",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.1.0",
-                        "statuses": ">= 1.4.0 < 2"
+                        "statuses": "1.4.0"
                     }
                 },
                 "iconv-lite": {
@@ -5997,7 +5715,7 @@
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "mime-db": {
@@ -6012,7 +5730,7 @@
                     "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "~1.37.0"
+                        "mime-db": "1.37.0"
                     }
                 },
                 "path-to-regexp": {
@@ -6052,18 +5770,18 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "destroy": "~1.0.4",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
+                        "depd": "1.1.2",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
                         "fresh": "0.5.2",
-                        "http-errors": "~1.6.2",
+                        "http-errors": "1.6.3",
                         "mime": "1.4.1",
                         "ms": "2.0.0",
-                        "on-finished": "~2.3.0",
-                        "range-parser": "~1.2.0",
-                        "statuses": "~1.4.0"
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.4.0"
                     }
                 },
                 "serve-static": {
@@ -6072,9 +5790,9 @@
                     "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
                     "dev": true,
                     "requires": {
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "parseurl": "~1.3.2",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "parseurl": "1.3.2",
                         "send": "0.16.2"
                     }
                 },
@@ -6091,7 +5809,7 @@
                     "dev": true,
                     "requires": {
                         "media-typer": "0.3.0",
-                        "mime-types": "~2.1.18"
+                        "mime-types": "2.1.21"
                     }
                 }
             }
@@ -6108,7 +5826,7 @@
             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
             "dev": true,
             "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
             }
         },
         "extglob": {
@@ -6116,7 +5834,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "extract-text-webpack-plugin": {
@@ -6125,10 +5843,10 @@
             "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
             "dev": true,
             "requires": {
-                "async": "^2.4.1",
-                "loader-utils": "^1.1.0",
-                "schema-utils": "^0.3.0",
-                "webpack-sources": "^1.0.1"
+                "async": "2.6.0",
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0",
+                "webpack-sources": "1.0.2"
             },
             "dependencies": {
                 "schema-utils": {
@@ -6137,7 +5855,7 @@
                     "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
                     "dev": true,
                     "requires": {
-                        "ajv": "^5.0.0"
+                        "ajv": "5.3.0"
                     }
                 }
             }
@@ -6163,7 +5881,7 @@
             "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
             "dev": true,
             "requires": {
-                "websocket-driver": ">=0.5.1"
+                "websocket-driver": "0.7.0"
             }
         },
         "file-loader": {
@@ -6172,8 +5890,8 @@
             "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2",
-                "schema-utils": "^0.4.5"
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.4.7"
             }
         },
         "filename-regex": {
@@ -6187,8 +5905,8 @@
             "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.3",
-                "minimatch": "^3.0.3"
+                "glob": "7.1.3",
+                "minimatch": "3.0.4"
             }
         },
         "fill-range": {
@@ -6196,11 +5914,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "3.1.0",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
             }
         },
         "finalhandler": {
@@ -6210,12 +5928,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.4.0",
-                "unpipe": "~1.0.0"
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.4.0",
+                "unpipe": "1.0.0"
             },
             "dependencies": {
                 "encodeurl": {
@@ -6238,9 +5956,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "commondir": "1.0.1",
+                "make-dir": "1.3.0",
+                "pkg-dir": "2.0.0"
             }
         },
         "find-up": {
@@ -6249,8 +5967,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "flush-write-stream": {
@@ -6259,8 +5977,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -6281,13 +5999,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -6296,7 +6014,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -6311,7 +6029,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "foreach": {
@@ -6330,9 +6048,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.17"
             },
             "dependencies": {
                 "combined-stream": {
@@ -6340,7 +6058,7 @@
                     "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
                     "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
                     "requires": {
-                        "delayed-stream": "~1.0.0"
+                        "delayed-stream": "1.0.0"
                     }
                 }
             }
@@ -6357,7 +6075,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fresh": {
@@ -6372,8 +6090,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -6394,13 +6112,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -6409,7 +6127,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -6420,7 +6138,7 @@
             "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
             "dev": true,
             "requires": {
-                "null-check": "^1.0.0"
+                "null-check": "1.0.0"
             }
         },
         "fs-extra": {
@@ -6429,9 +6147,9 @@
             "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
             }
         },
         "fs-write-stream-atomic": {
@@ -6440,10 +6158,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "1.0.34"
             }
         },
         "fs.realpath": {
@@ -6457,8 +6175,8 @@
             "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "2.11.1",
+                "node-pre-gyp": "0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -6480,8 +6198,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "balanced-match": {
@@ -6492,7 +6210,7 @@
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -6546,7 +6264,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
@@ -6559,14 +6277,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
                     }
                 },
                 "glob": {
@@ -6574,12 +6292,12 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-unicode": {
@@ -6592,7 +6310,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "ignore-walk": {
@@ -6600,7 +6318,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
@@ -6608,8 +6326,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -6625,7 +6343,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -6637,7 +6355,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -6648,8 +6366,8 @@
                     "version": "2.2.4",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "minizlib": {
@@ -6657,7 +6375,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "mkdirp": {
@@ -6683,9 +6401,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -6693,16 +6411,16 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.7",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
                     }
                 },
                 "nopt": {
@@ -6710,8 +6428,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "npm-bundled": {
@@ -6724,8 +6442,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
@@ -6733,10 +6451,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -6752,7 +6470,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
@@ -6770,8 +6488,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -6789,10 +6507,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.5.1",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -6807,13 +6525,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
@@ -6821,7 +6539,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
@@ -6857,9 +6575,9 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "string_decoder": {
@@ -6867,14 +6585,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
@@ -6887,13 +6605,13 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -6906,7 +6624,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
@@ -6925,10 +6643,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "function-bind": {
@@ -6943,14 +6661,14 @@
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
+                "aproba": "1.2.0",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
             }
         },
         "gaze": {
@@ -6959,7 +6677,7 @@
             "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
             "dev": true,
             "requires": {
-                "globule": "^1.0.0"
+                "globule": "1.2.0"
             }
         },
         "generate-function": {
@@ -6974,7 +6692,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "^1.0.0"
+                "is-property": "1.0.2"
             }
         },
         "get-caller-file": {
@@ -7006,20 +6724,20 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-            "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.2",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -7027,8 +6745,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "glob-parent": {
@@ -7036,7 +6754,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "requires": {
-                "is-glob": "^2.0.0"
+                "is-glob": "2.0.1"
             }
         },
         "globals": {
@@ -7051,12 +6769,12 @@
             "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
             "dev": true,
             "requires": {
-                "array-union": "^1.0.1",
-                "dir-glob": "^2.0.0",
-                "glob": "^7.1.2",
-                "ignore": "^3.3.5",
-                "pify": "^3.0.0",
-                "slash": "^1.0.0"
+                "array-union": "1.0.2",
+                "dir-glob": "2.0.0",
+                "glob": "7.1.3",
+                "ignore": "3.3.10",
+                "pify": "3.0.0",
+                "slash": "1.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -7065,12 +6783,12 @@
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "pify": {
@@ -7087,9 +6805,9 @@
             "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
             "dev": true,
             "requires": {
-                "glob": "~7.1.1",
-                "lodash": "~4.17.4",
-                "minimatch": "~3.0.2"
+                "glob": "7.1.2",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4"
             },
             "dependencies": {
                 "glob": {
@@ -7098,12 +6816,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -7131,10 +6849,10 @@
             "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "async": "2.6.0",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.3.9"
             },
             "dependencies": {
                 "source-map": {
@@ -7155,8 +6873,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
             "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "requires": {
-                "ajv": "^5.3.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.3.0",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -7165,7 +6883,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -7174,7 +6892,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-binary2": {
@@ -7224,9 +6942,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -7243,8 +6961,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -7253,7 +6971,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7262,7 +6980,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -7273,7 +6991,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -7283,7 +7001,7 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
             "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
             "requires": {
-                "inherits": "^2.0.1"
+                "inherits": "2.0.3"
             }
         },
         "hash.js": {
@@ -7291,8 +7009,8 @@
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
             }
         },
         "hawk": {
@@ -7301,10 +7019,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
             }
         },
         "he": {
@@ -7318,9 +7036,9 @@
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoek": {
@@ -7335,7 +7053,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "^1.0.0"
+                "parse-passwd": "1.0.0"
             }
         },
         "hosted-git-info": {
@@ -7350,10 +7068,10 @@
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "obuf": "^1.0.0",
-                "readable-stream": "^2.0.1",
-                "wbuf": "^1.1.0"
+                "inherits": "2.0.3",
+                "obuf": "1.1.2",
+                "readable-stream": "2.3.6",
+                "wbuf": "1.7.3"
             },
             "dependencies": {
                 "isarray": {
@@ -7374,13 +7092,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -7389,7 +7107,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -7406,13 +7124,13 @@
             "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.x",
-                "clean-css": "4.2.x",
-                "commander": "2.17.x",
-                "he": "1.1.x",
-                "param-case": "2.1.x",
-                "relateurl": "0.2.x",
-                "uglify-js": "3.4.x"
+                "camel-case": "3.0.0",
+                "clean-css": "4.2.1",
+                "commander": "2.17.1",
+                "he": "1.1.1",
+                "param-case": "2.1.1",
+                "relateurl": "0.2.7",
+                "uglify-js": "3.4.9"
             },
             "dependencies": {
                 "commander": {
@@ -7433,8 +7151,8 @@
                     "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
                     "dev": true,
                     "requires": {
-                        "commander": "~2.17.1",
-                        "source-map": "~0.6.1"
+                        "commander": "2.17.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -7445,12 +7163,12 @@
             "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
             "dev": true,
             "requires": {
-                "bluebird": "^3.4.7",
-                "html-minifier": "^3.2.3",
-                "loader-utils": "^0.2.16",
-                "lodash": "^4.17.3",
-                "pretty-error": "^2.0.2",
-                "toposort": "^1.0.0"
+                "bluebird": "3.5.1",
+                "html-minifier": "3.5.20",
+                "loader-utils": "0.2.17",
+                "lodash": "4.17.11",
+                "pretty-error": "2.1.1",
+                "toposort": "1.0.7"
             },
             "dependencies": {
                 "loader-utils": {
@@ -7459,10 +7177,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
+                        "big.js": "3.2.0",
+                        "emojis-list": "2.1.0",
+                        "json5": "0.5.1",
+                        "object-assign": "4.1.1"
                     }
                 }
             }
@@ -7473,10 +7191,10 @@
             "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
             "dev": true,
             "requires": {
-                "domelementtype": "1",
-                "domhandler": "2.1",
-                "domutils": "1.1",
-                "readable-stream": "1.0"
+                "domelementtype": "1.3.0",
+                "domhandler": "2.1.0",
+                "domutils": "1.1.6",
+                "readable-stream": "1.0.34"
             },
             "dependencies": {
                 "domutils": {
@@ -7485,7 +7203,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1"
+                        "domelementtype": "1.3.0"
                     }
                 }
             }
@@ -7505,7 +7223,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": ">= 1.3.1 < 2"
+                "statuses": "1.3.1"
             },
             "dependencies": {
                 "setprototypeof": {
@@ -7528,8 +7246,8 @@
             "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.x.x",
-                "requires-port": "1.x.x"
+                "eventemitter3": "1.2.0",
+                "requires-port": "1.0.0"
             }
         },
         "http-proxy-middleware": {
@@ -7538,10 +7256,10 @@
             "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
             "dev": true,
             "requires": {
-                "http-proxy": "^1.16.2",
-                "is-glob": "^3.1.0",
-                "lodash": "^4.17.2",
-                "micromatch": "^2.3.11"
+                "http-proxy": "1.16.2",
+                "is-glob": "3.1.0",
+                "lodash": "4.17.11",
+                "micromatch": "2.3.11"
             },
             "dependencies": {
                 "is-extglob": {
@@ -7556,7 +7274,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -7566,9 +7284,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.15.1"
             }
         },
         "https-browserify": {
@@ -7618,7 +7336,7 @@
             "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
             "dev": true,
             "requires": {
-                "import-from": "^2.1.0"
+                "import-from": "2.1.0"
             }
         },
         "import-from": {
@@ -7627,7 +7345,7 @@
             "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             }
         },
         "import-local": {
@@ -7636,8 +7354,8 @@
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^2.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "2.0.0",
+                "resolve-cwd": "2.0.0"
             }
         },
         "imurmurhash": {
@@ -7658,7 +7376,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "indexof": {
@@ -7672,8 +7390,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -7693,13 +7411,13 @@
             "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
             "dev": true,
             "requires": {
-                "meow": "^3.3.0"
+                "meow": "3.7.0"
             }
         },
         "interpret": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
-            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
         },
         "invariant": {
             "version": "2.2.4",
@@ -7707,7 +7425,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "invert-kv": {
@@ -7721,11 +7439,11 @@
             "resolved": "https://registry.npmjs.org/iod/-/iod-1.1.1.tgz",
             "integrity": "sha1-p74GdneaX+qYcwxSXhBzrXmWrBY=",
             "requires": {
-                "async": "^0.9.0",
-                "jjv": "^1.0.2",
-                "jjve": "^0.4.0",
-                "lodash": "^2.4.1",
-                "request": "^2.44.0"
+                "async": "0.9.2",
+                "jjv": "1.0.2",
+                "jjve": "0.4.0",
+                "lodash": "2.4.2",
+                "request": "2.88.0"
             },
             "dependencies": {
                 "async": {
@@ -7779,7 +7497,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7801,7 +7519,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.10.0"
             }
         },
         "is-buffer": {
@@ -7815,7 +7533,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-callable": {
@@ -7830,7 +7548,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7853,9 +7571,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7882,7 +7600,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -7901,7 +7619,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-fullwidth-code-point": {
@@ -7910,7 +7628,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-glob": {
@@ -7918,7 +7636,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "is-module": {
@@ -7933,10 +7651,10 @@
             "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
             "dev": true,
             "requires": {
-                "generate-function": "^2.0.0",
-                "generate-object-property": "^1.1.0",
-                "jsonpointer": "^4.0.0",
-                "xtend": "^4.0.0"
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
             }
         },
         "is-number": {
@@ -7944,7 +7662,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-path-cwd": {
@@ -7959,7 +7677,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "^1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
@@ -7968,7 +7686,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-plain-object": {
@@ -7977,7 +7695,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -8010,7 +7728,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-stream": {
@@ -8025,7 +7743,7 @@
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -8062,7 +7780,7 @@
             "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
             "dev": true,
             "requires": {
-                "buffer-alloc": "^1.2.0"
+                "buffer-alloc": "1.2.0"
             }
         },
         "isexe": {
@@ -8097,18 +7815,18 @@
             "integrity": "sha512-8W5oeAGWXhtTJjAyVfvavOLVyZCTNCKsyF6GON/INKlBdO7uJ/bv3qnPj5M6ERKzmMCJS1kntnjjGuJ86fn3rQ==",
             "dev": true,
             "requires": {
-                "async": "^2.6.1",
-                "compare-versions": "^3.2.1",
-                "fileset": "^2.0.3",
-                "istanbul-lib-coverage": "^2.0.1",
-                "istanbul-lib-hook": "^2.0.1",
-                "istanbul-lib-instrument": "^3.0.0",
-                "istanbul-lib-report": "^2.0.2",
-                "istanbul-lib-source-maps": "^2.0.1",
-                "istanbul-reports": "^2.0.1",
-                "js-yaml": "^3.12.0",
-                "make-dir": "^1.3.0",
-                "once": "^1.4.0"
+                "async": "2.6.1",
+                "compare-versions": "3.4.0",
+                "fileset": "2.0.3",
+                "istanbul-lib-coverage": "2.0.1",
+                "istanbul-lib-hook": "2.0.1",
+                "istanbul-lib-instrument": "3.0.0",
+                "istanbul-lib-report": "2.0.2",
+                "istanbul-lib-source-maps": "2.0.1",
+                "istanbul-reports": "2.0.1",
+                "js-yaml": "3.12.0",
+                "make-dir": "1.3.0",
+                "once": "1.4.0"
             },
             "dependencies": {
                 "async": {
@@ -8117,7 +7835,7 @@
                     "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
                     "dev": true,
                     "requires": {
-                        "lodash": "^4.17.10"
+                        "lodash": "4.17.11"
                     }
                 },
                 "esprima": {
@@ -8132,13 +7850,13 @@
                     "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/generator": "^7.0.0",
-                        "@babel/parser": "^7.0.0",
-                        "@babel/template": "^7.0.0",
-                        "@babel/traverse": "^7.0.0",
-                        "@babel/types": "^7.0.0",
-                        "istanbul-lib-coverage": "^2.0.1",
-                        "semver": "^5.5.0"
+                        "@babel/generator": "7.1.3",
+                        "@babel/parser": "7.1.3",
+                        "@babel/template": "7.1.2",
+                        "@babel/traverse": "7.1.4",
+                        "@babel/types": "7.1.3",
+                        "istanbul-lib-coverage": "2.0.1",
+                        "semver": "5.6.0"
                     }
                 },
                 "js-yaml": {
@@ -8147,8 +7865,8 @@
                     "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
                     "dev": true,
                     "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^4.0.0"
+                        "argparse": "1.0.9",
+                        "esprima": "4.0.1"
                     }
                 },
                 "make-dir": {
@@ -8157,7 +7875,7 @@
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -8180,10 +7898,10 @@
             "integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
             "dev": true,
             "requires": {
-                "convert-source-map": "^1.5.0",
-                "istanbul-lib-instrument": "^1.7.3",
-                "loader-utils": "^1.1.0",
-                "schema-utils": "^0.3.0"
+                "convert-source-map": "1.6.0",
+                "istanbul-lib-instrument": "1.10.2",
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0"
             },
             "dependencies": {
                 "schema-utils": {
@@ -8192,7 +7910,7 @@
                     "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
                     "dev": true,
                     "requires": {
-                        "ajv": "^5.0.0"
+                        "ajv": "5.3.0"
                     }
                 }
             }
@@ -8209,7 +7927,7 @@
             "integrity": "sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==",
             "dev": true,
             "requires": {
-                "append-transform": "^1.0.0"
+                "append-transform": "1.0.0"
             }
         },
         "istanbul-lib-instrument": {
@@ -8218,13 +7936,13 @@
             "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
             "dev": true,
             "requires": {
-                "babel-generator": "^6.18.0",
-                "babel-template": "^6.16.0",
-                "babel-traverse": "^6.18.0",
-                "babel-types": "^6.18.0",
-                "babylon": "^6.18.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "semver": "^5.3.0"
+                "babel-generator": "6.26.1",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.2.1",
+                "semver": "5.4.1"
             },
             "dependencies": {
                 "istanbul-lib-coverage": {
@@ -8241,9 +7959,9 @@
             "integrity": "sha512-rJ8uR3peeIrwAxoDEbK4dJ7cqqtxBisZKCuwkMtMv0xYzaAnsAi3AHrHPAAtNXzG/bcCgZZ3OJVqm1DTi9ap2Q==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^2.0.1",
-                "make-dir": "^1.3.0",
-                "supports-color": "^5.4.0"
+                "istanbul-lib-coverage": "2.0.1",
+                "make-dir": "1.3.0",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "has-flag": {
@@ -8264,7 +7982,7 @@
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -8279,7 +7997,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -8290,11 +8008,11 @@
             "integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0",
-                "istanbul-lib-coverage": "^2.0.1",
-                "make-dir": "^1.3.0",
-                "rimraf": "^2.6.2",
-                "source-map": "^0.6.1"
+                "debug": "3.2.6",
+                "istanbul-lib-coverage": "2.0.1",
+                "make-dir": "1.3.0",
+                "rimraf": "2.6.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "debug": {
@@ -8303,7 +8021,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "make-dir": {
@@ -8312,7 +8030,7 @@
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "ms": {
@@ -8341,7 +8059,7 @@
             "integrity": "sha512-CT0QgMBJqs6NJLF678ZHcquUAZIoBIUNzdJrRJfpkI9OnzG6MkUfHxbJC3ln981dMswC7/B1mfX3LNkhgJxsuw==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.0.11"
+                "handlebars": "4.0.12"
             }
         },
         "jasmine-core": {
@@ -8356,8 +8074,8 @@
             "integrity": "sha512-u/7AT9SkuZsUfFBLLzbErohTGNsEUCKaQbsVYnLFW1gEuL2DzmBL4n8v90uZsqIqlWvWUgian8J6yOt5Fyk/+A==",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1",
-                "xmldom": "^0.1.22"
+                "mkdirp": "0.5.1",
+                "xmldom": "0.1.27"
             }
         },
         "jasmine-spec-reporter": {
@@ -8367,6 +8085,14 @@
             "dev": true,
             "requires": {
                 "colors": "1.1.2"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                    "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                    "dev": true
+                }
             }
         },
         "jjv": {
@@ -8402,8 +8128,8 @@
             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^2.6.0"
+                "argparse": "1.0.9",
+                "esprima": "2.7.3"
             },
             "dependencies": {
                 "esprima": {
@@ -8454,7 +8180,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -8464,9 +8190,8 @@
         },
         "json-typescript-mapper": {
             "version": "github:luciorubeens/json-typescript-mapper#67e4e5e67700b2f81c4006b8a9fb32dcb840f5dd",
-            "from": "github:luciorubeens/json-typescript-mapper#master",
             "requires": {
-                "reflect-metadata": "^0.1.3"
+                "reflect-metadata": "0.1.10"
             }
         },
         "json3": {
@@ -8487,7 +8212,7 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "4.1.11"
             }
         },
         "jsonify": {
@@ -8520,11 +8245,11 @@
             "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
             "dev": true,
             "requires": {
-                "core-js": "~2.3.0",
-                "es6-promise": "~3.0.2",
-                "lie": "~3.1.0",
-                "pako": "~1.0.2",
-                "readable-stream": "~2.0.6"
+                "core-js": "2.3.0",
+                "es6-promise": "3.0.2",
+                "lie": "3.1.1",
+                "pako": "1.0.6",
+                "readable-stream": "2.0.6"
             },
             "dependencies": {
                 "core-js": {
@@ -8551,7 +8276,7 @@
                     "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
                     "dev": true,
                     "requires": {
-                        "immediate": "~3.0.5"
+                        "immediate": "3.0.6"
                     }
                 },
                 "pako": {
@@ -8566,12 +8291,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
                     }
                 }
             }
@@ -8582,31 +8307,31 @@
             "integrity": "sha512-ZTjyuDXVXhXsvJ1E4CnZzbCjSxD6sEdzEsFYogLuZM0yqvg/mgz+O+R1jb0J7uAQeuzdY8kJgx6hSNXLwFuHIQ==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.3.0",
-                "body-parser": "^1.16.1",
-                "chokidar": "^2.0.3",
-                "colors": "^1.1.0",
-                "combine-lists": "^1.0.0",
-                "connect": "^3.6.0",
-                "core-js": "^2.2.0",
-                "di": "^0.0.1",
-                "dom-serialize": "^2.2.0",
-                "expand-braces": "^0.1.1",
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "http-proxy": "^1.13.0",
-                "isbinaryfile": "^3.0.0",
-                "lodash": "^4.17.4",
-                "log4js": "^3.0.0",
-                "mime": "^2.3.1",
-                "minimatch": "^3.0.2",
-                "optimist": "^0.6.1",
-                "qjobs": "^1.1.4",
-                "range-parser": "^1.2.0",
-                "rimraf": "^2.6.0",
-                "safe-buffer": "^5.0.1",
+                "bluebird": "3.5.1",
+                "body-parser": "1.18.2",
+                "chokidar": "2.0.4",
+                "colors": "1.3.2",
+                "combine-lists": "1.0.1",
+                "connect": "3.6.5",
+                "core-js": "2.5.3",
+                "di": "0.0.1",
+                "dom-serialize": "2.2.1",
+                "expand-braces": "0.1.2",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.11",
+                "http-proxy": "1.16.2",
+                "isbinaryfile": "3.0.3",
+                "lodash": "4.17.11",
+                "log4js": "3.0.6",
+                "mime": "2.3.1",
+                "minimatch": "3.0.4",
+                "optimist": "0.6.1",
+                "qjobs": "1.2.0",
+                "range-parser": "1.2.0",
+                "rimraf": "2.6.2",
+                "safe-buffer": "5.1.1",
                 "socket.io": "2.1.1",
-                "source-map": "^0.6.1",
+                "source-map": "0.6.1",
                 "tmp": "0.0.33",
                 "useragent": "2.2.1"
             },
@@ -8617,8 +8342,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "^3.1.4",
-                        "normalize-path": "^2.1.1"
+                        "micromatch": "3.1.10",
+                        "normalize-path": "2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -8639,16 +8364,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -8657,7 +8382,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -8668,19 +8393,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.0",
-                        "braces": "^2.3.0",
-                        "fsevents": "^1.2.2",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "lodash.debounce": "^4.0.8",
-                        "normalize-path": "^2.1.1",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0",
-                        "upath": "^1.0.5"
+                        "anymatch": "2.0.0",
+                        "async-each": "1.0.1",
+                        "braces": "2.3.2",
+                        "fsevents": "1.2.4",
+                        "glob-parent": "3.1.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "4.0.0",
+                        "lodash.debounce": "4.0.8",
+                        "normalize-path": "2.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0",
+                        "upath": "1.1.0"
                     }
                 },
                 "connect": {
@@ -8691,7 +8416,7 @@
                     "requires": {
                         "debug": "2.6.9",
                         "finalhandler": "1.0.6",
-                        "parseurl": "~1.3.2",
+                        "parseurl": "1.3.2",
                         "utils-merge": "1.0.1"
                     }
                 },
@@ -8701,8 +8426,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
+                        "is-descriptor": "1.0.2",
+                        "isobject": "3.0.1"
                     }
                 },
                 "expand-brackets": {
@@ -8711,13 +8436,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -8726,7 +8451,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -8735,7 +8460,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-descriptor": {
@@ -8744,9 +8469,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
                             }
                         },
                         "kind-of": {
@@ -8763,8 +8488,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -8773,7 +8498,7 @@
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "^2.0.4"
+                                "is-plain-object": "2.0.4"
                             }
                         }
                     }
@@ -8784,14 +8509,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -8800,7 +8525,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -8809,7 +8534,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -8820,10 +8545,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -8832,7 +8557,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -8844,12 +8569,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "~1.0.1",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "statuses": "~1.3.1",
-                        "unpipe": "~1.0.0"
+                        "encodeurl": "1.0.1",
+                        "escape-html": "1.0.3",
+                        "on-finished": "2.3.0",
+                        "parseurl": "1.3.2",
+                        "statuses": "1.3.1",
+                        "unpipe": "1.0.0"
                     }
                 },
                 "fsevents": {
@@ -8859,8 +8584,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "nan": "^2.9.2",
-                        "node-pre-gyp": "^0.10.0"
+                        "nan": "2.11.1",
+                        "node-pre-gyp": "0.10.0"
                     },
                     "dependencies": {
                         "abbrev": {
@@ -8886,8 +8611,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "delegates": "^1.0.0",
-                                "readable-stream": "^2.0.6"
+                                "delegates": "1.0.0",
+                                "readable-stream": "2.3.6"
                             }
                         },
                         "balanced-match": {
@@ -8900,7 +8625,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "balanced-match": "^1.0.0",
+                                "balanced-match": "1.0.0",
                                 "concat-map": "0.0.1"
                             }
                         },
@@ -8964,7 +8689,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "minipass": "^2.2.1"
+                                "minipass": "2.2.4"
                             }
                         },
                         "fs.realpath": {
@@ -8979,14 +8704,14 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "aproba": "^1.0.3",
-                                "console-control-strings": "^1.0.0",
-                                "has-unicode": "^2.0.0",
-                                "object-assign": "^4.1.0",
-                                "signal-exit": "^3.0.0",
-                                "string-width": "^1.0.1",
-                                "strip-ansi": "^3.0.1",
-                                "wide-align": "^1.1.0"
+                                "aproba": "1.2.0",
+                                "console-control-strings": "1.1.0",
+                                "has-unicode": "2.0.1",
+                                "object-assign": "4.1.1",
+                                "signal-exit": "3.0.2",
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1",
+                                "wide-align": "1.1.2"
                             }
                         },
                         "glob": {
@@ -8995,12 +8720,12 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
                             }
                         },
                         "has-unicode": {
@@ -9015,7 +8740,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "safer-buffer": "^2.1.0"
+                                "safer-buffer": "2.1.2"
                             }
                         },
                         "ignore-walk": {
@@ -9024,7 +8749,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "minimatch": "^3.0.4"
+                                "minimatch": "3.0.4"
                             }
                         },
                         "inflight": {
@@ -9033,8 +8758,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "once": "^1.3.0",
-                                "wrappy": "1"
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
                             }
                         },
                         "inherits": {
@@ -9053,7 +8778,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                             }
                         },
                         "isarray": {
@@ -9067,7 +8792,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "brace-expansion": "^1.1.7"
+                                "brace-expansion": "1.1.11"
                             }
                         },
                         "minimist": {
@@ -9080,8 +8805,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "^5.1.1",
-                                "yallist": "^3.0.0"
+                                "safe-buffer": "5.1.1",
+                                "yallist": "3.0.2"
                             }
                         },
                         "minizlib": {
@@ -9090,7 +8815,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "minipass": "^2.2.1"
+                                "minipass": "2.2.4"
                             }
                         },
                         "mkdirp": {
@@ -9113,9 +8838,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "debug": "^2.1.2",
-                                "iconv-lite": "^0.4.4",
-                                "sax": "^1.2.4"
+                                "debug": "2.6.9",
+                                "iconv-lite": "0.4.21",
+                                "sax": "1.2.4"
                             }
                         },
                         "node-pre-gyp": {
@@ -9124,16 +8849,16 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "detect-libc": "^1.0.2",
-                                "mkdirp": "^0.5.1",
-                                "needle": "^2.2.0",
-                                "nopt": "^4.0.1",
-                                "npm-packlist": "^1.1.6",
-                                "npmlog": "^4.0.2",
-                                "rc": "^1.1.7",
-                                "rimraf": "^2.6.1",
-                                "semver": "^5.3.0",
-                                "tar": "^4"
+                                "detect-libc": "1.0.3",
+                                "mkdirp": "0.5.1",
+                                "needle": "2.2.0",
+                                "nopt": "4.0.1",
+                                "npm-packlist": "1.1.10",
+                                "npmlog": "4.1.2",
+                                "rc": "1.2.7",
+                                "rimraf": "2.6.2",
+                                "semver": "5.5.0",
+                                "tar": "4.4.1"
                             }
                         },
                         "nopt": {
@@ -9142,8 +8867,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "abbrev": "1",
-                                "osenv": "^0.1.4"
+                                "abbrev": "1.1.1",
+                                "osenv": "0.1.5"
                             }
                         },
                         "npm-bundled": {
@@ -9158,8 +8883,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "ignore-walk": "^3.0.1",
-                                "npm-bundled": "^1.0.1"
+                                "ignore-walk": "3.0.1",
+                                "npm-bundled": "1.0.3"
                             }
                         },
                         "npmlog": {
@@ -9168,10 +8893,10 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "are-we-there-yet": "~1.1.2",
-                                "console-control-strings": "~1.1.0",
-                                "gauge": "~2.7.3",
-                                "set-blocking": "~2.0.0"
+                                "are-we-there-yet": "1.1.4",
+                                "console-control-strings": "1.1.0",
+                                "gauge": "2.7.4",
+                                "set-blocking": "2.0.0"
                             }
                         },
                         "number-is-nan": {
@@ -9190,7 +8915,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "wrappy": "1"
+                                "wrappy": "1.0.2"
                             }
                         },
                         "os-homedir": {
@@ -9211,8 +8936,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "os-homedir": "^1.0.0",
-                                "os-tmpdir": "^1.0.0"
+                                "os-homedir": "1.0.2",
+                                "os-tmpdir": "1.0.2"
                             }
                         },
                         "path-is-absolute": {
@@ -9233,10 +8958,10 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "deep-extend": "^0.5.1",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.5.1",
+                                "ini": "1.3.5",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                             },
                             "dependencies": {
                                 "minimist": {
@@ -9253,13 +8978,13 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "rimraf": {
@@ -9268,7 +8993,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "glob": "^7.0.5"
+                                "glob": "7.1.2"
                             }
                         },
                         "safe-buffer": {
@@ -9311,9 +9036,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         },
                         "string_decoder": {
@@ -9322,7 +9047,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.1"
                             }
                         },
                         "strip-ansi": {
@@ -9330,7 +9055,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                             }
                         },
                         "strip-json-comments": {
@@ -9345,13 +9070,13 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "chownr": "^1.0.1",
-                                "fs-minipass": "^1.2.5",
-                                "minipass": "^2.2.4",
-                                "minizlib": "^1.1.0",
-                                "mkdirp": "^0.5.0",
-                                "safe-buffer": "^5.1.1",
-                                "yallist": "^3.0.2"
+                                "chownr": "1.0.1",
+                                "fs-minipass": "1.2.5",
+                                "minipass": "2.2.4",
+                                "minizlib": "1.1.0",
+                                "mkdirp": "0.5.1",
+                                "safe-buffer": "5.1.1",
+                                "yallist": "3.0.2"
                             }
                         },
                         "util-deprecate": {
@@ -9366,7 +9091,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "string-width": "^1.0.2"
+                                "string-width": "1.0.2"
                             }
                         },
                         "wrappy": {
@@ -9387,12 +9112,12 @@
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "glob-parent": {
@@ -9401,8 +9126,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
+                        "is-glob": "3.1.0",
+                        "path-dirname": "1.0.2"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -9411,7 +9136,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "^2.1.0"
+                                "is-extglob": "2.1.1"
                             }
                         }
                     }
@@ -9422,7 +9147,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -9431,7 +9156,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -9442,7 +9167,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -9451,7 +9176,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -9468,7 +9193,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "is-number": {
@@ -9477,7 +9202,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -9486,7 +9211,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -9509,19 +9234,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.13",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 },
                 "mime": {
@@ -9543,17 +9268,17 @@
                     "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "fragment-cache": "^0.2.1",
-                        "is-windows": "^1.0.2",
-                        "kind-of": "^6.0.2",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "fragment-cache": "0.2.1",
+                        "is-windows": "1.0.2",
+                        "kind-of": "6.0.2",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 },
                 "source-map": {
@@ -9568,10 +9293,10 @@
                     "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
                     "dev": true,
                     "requires": {
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "regex-not": "^1.0.2",
-                        "safe-regex": "^1.1.0"
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "regex-not": "1.0.2",
+                        "safe-regex": "1.1.0"
                     },
                     "dependencies": {
                         "regex-not": {
@@ -9580,8 +9305,8 @@
                             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
                             "dev": true,
                             "requires": {
-                                "extend-shallow": "^3.0.2",
-                                "safe-regex": "^1.1.0"
+                                "extend-shallow": "3.0.2",
+                                "safe-regex": "1.1.0"
                             }
                         }
                     }
@@ -9594,8 +9319,8 @@
             "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
             "dev": true,
             "requires": {
-                "fs-access": "^1.0.0",
-                "which": "^1.2.1"
+                "fs-access": "1.0.1",
+                "which": "1.3.0"
             }
         },
         "karma-cli": {
@@ -9604,7 +9329,7 @@
             "integrity": "sha1-rmw8WKMTodALRRZMRVubhs4X+WA=",
             "dev": true,
             "requires": {
-                "resolve": "^1.1.6"
+                "resolve": "1.8.1"
             }
         },
         "karma-coverage-istanbul-reporter": {
@@ -9613,8 +9338,8 @@
             "integrity": "sha512-xJS7QSQIVU6VK9HuJ/ieE5yynxKhjCCkd96NLY/BX/HXsx0CskU9JJiMQbd4cHALiddMwI4OWh1IIzeWrsavJw==",
             "dev": true,
             "requires": {
-                "istanbul-api": "^2.0.5",
-                "minimatch": "^3.0.4"
+                "istanbul-api": "2.0.6",
+                "minimatch": "3.0.4"
             }
         },
         "karma-jasmine": {
@@ -9635,7 +9360,7 @@
             "integrity": "sha512-HcPqdAusNez/ywa+biN4EphGz62MmQyPggUsDfsHqa7tSe4jdsxgvTKuDfIazjL+IOxpVWyT7Pr4dhAV+sxX5Q==",
             "dev": true,
             "requires": {
-                "source-map-support": "^0.5.5"
+                "source-map-support": "0.5.9"
             },
             "dependencies": {
                 "source-map": {
@@ -9650,8 +9375,8 @@
                     "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
                     "dev": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
+                        "buffer-from": "1.1.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -9662,7 +9387,7 @@
             "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
             "dev": true,
             "requires": {
-                "colors": "^1.1.2"
+                "colors": "1.3.2"
             }
         },
         "karma-webpack": {
@@ -9671,12 +9396,12 @@
             "integrity": "sha512-nRudGJWstvVuA6Tbju9tyGUfXTtI1UXMXoRHVmM2/78D0q6s/Ye2IC157PKNDC15PWFGR0mVIRtWLAdcfsRJoA==",
             "dev": true,
             "requires": {
-                "async": "^2.0.0",
-                "babel-runtime": "^6.0.0",
-                "loader-utils": "^1.0.0",
-                "lodash": "^4.0.0",
-                "source-map": "^0.5.6",
-                "webpack-dev-middleware": "^2.0.6"
+                "async": "2.6.0",
+                "babel-runtime": "6.26.0",
+                "loader-utils": "1.1.0",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "webpack-dev-middleware": "2.0.6"
             },
             "dependencies": {
                 "mime": {
@@ -9691,13 +9416,13 @@
                     "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
                     "dev": true,
                     "requires": {
-                        "loud-rejection": "^1.6.0",
-                        "memory-fs": "~0.4.1",
-                        "mime": "^2.1.0",
-                        "path-is-absolute": "^1.0.0",
-                        "range-parser": "^1.0.3",
-                        "url-join": "^2.0.2",
-                        "webpack-log": "^1.0.1"
+                        "loud-rejection": "1.6.0",
+                        "memory-fs": "0.4.1",
+                        "mime": "2.3.1",
+                        "path-is-absolute": "1.0.1",
+                        "range-parser": "1.2.0",
+                        "url-join": "2.0.5",
+                        "webpack-log": "1.2.0"
                     }
                 }
             }
@@ -9713,7 +9438,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
             }
         },
         "lazy-cache": {
@@ -9728,7 +9453,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "less": {
@@ -9737,14 +9462,14 @@
             "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
             "dev": true,
             "requires": {
-                "errno": "^0.1.1",
-                "graceful-fs": "^4.1.2",
-                "image-size": "~0.5.0",
-                "mime": "^1.2.11",
-                "mkdirp": "^0.5.0",
-                "promise": "^7.1.1",
+                "errno": "0.1.4",
+                "graceful-fs": "4.1.11",
+                "image-size": "0.5.5",
+                "mime": "1.4.1",
+                "mkdirp": "0.5.1",
+                "promise": "7.3.1",
                 "request": "2.81.0",
-                "source-map": "^0.5.3"
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "ajv": {
@@ -9754,8 +9479,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
                     }
                 },
                 "assert-plus": {
@@ -9779,9 +9504,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.5",
-                        "mime-types": "^2.1.12"
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
                     }
                 },
                 "har-schema": {
@@ -9798,8 +9523,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "^4.9.1",
-                        "har-schema": "^1.0.5"
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
                     }
                 },
                 "http-signature": {
@@ -9809,9 +9534,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "^0.2.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.15.1"
                     }
                 },
                 "performance-now": {
@@ -9835,28 +9560,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "~0.6.0",
-                        "aws4": "^1.2.1",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.5",
-                        "extend": "~3.0.0",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.1.1",
-                        "har-validator": "~4.2.1",
-                        "hawk": "~3.1.3",
-                        "http-signature": "~1.1.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.7",
-                        "oauth-sign": "~0.8.1",
-                        "performance-now": "^0.2.0",
-                        "qs": "~6.4.0",
-                        "safe-buffer": "^5.0.1",
-                        "stringstream": "~0.0.4",
-                        "tough-cookie": "~2.3.0",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.0.0"
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.1.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.1.0"
                     }
                 }
             }
@@ -9867,9 +9592,9 @@
             "integrity": "sha512-KNTsgCE9tMOM70+ddxp9yyt9iHqgmSs0yTZc5XH5Wo+g80RWRIYNqE58QJKm/yMud5wZEvz50ugRDuzVIkyahg==",
             "dev": true,
             "requires": {
-                "clone": "^2.1.1",
-                "loader-utils": "^1.1.0",
-                "pify": "^3.0.0"
+                "clone": "2.1.2",
+                "loader-utils": "1.1.0",
+                "pify": "3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -9886,7 +9611,7 @@
             "integrity": "sha512-Of/H79rZqm2aeg4RnP9SMSh19qkKemoLT5VaJV58uH5AxeYWEcBgGFs753JEJ/Hm6BPvQVfIlrrjoBwYj8p7Tw==",
             "dev": true,
             "requires": {
-                "ejs": "^2.5.7"
+                "ejs": "2.6.1"
             }
         },
         "lie": {
@@ -9894,7 +9619,7 @@
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
             "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
             "requires": {
-                "immediate": "~3.0.5"
+                "immediate": "3.0.6"
             }
         },
         "livereload-js": {
@@ -9909,11 +9634,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
             }
         },
         "loader-runner": {
@@ -9928,9 +9653,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0"
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
             }
         },
         "localforage": {
@@ -9946,7 +9671,7 @@
             "resolved": "https://registry.npmjs.org/localforage-cordovasqlitedriver/-/localforage-cordovasqlitedriver-1.7.0.tgz",
             "integrity": "sha1-i5OVd1nuaI06WNW6fAR39sy1ODg=",
             "requires": {
-                "localforage": ">=1.5.0"
+                "localforage": "1.7.1"
             }
         },
         "locate-path": {
@@ -9955,8 +9680,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             },
             "dependencies": {
                 "path-exists": {
@@ -10008,7 +9733,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "2.3.0"
             }
         },
         "log4js": {
@@ -10017,10 +9742,10 @@
             "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.5.5",
-                "date-format": "^1.2.0",
-                "debug": "^3.1.0",
-                "rfdc": "^1.1.2",
+                "circular-json": "0.5.7",
+                "date-format": "1.2.0",
+                "debug": "3.2.6",
+                "rfdc": "1.1.2",
                 "streamroller": "0.7.0"
             },
             "dependencies": {
@@ -10030,7 +9755,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -10053,8 +9778,8 @@
             "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
             "dev": true,
             "requires": {
-                "es6-symbol": "^3.1.1",
-                "object.assign": "^4.1.0"
+                "es6-symbol": "3.1.1",
+                "object.assign": "4.1.0"
             }
         },
         "long": {
@@ -10074,7 +9799,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "loud-rejection": {
@@ -10083,8 +9808,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "^0.4.1",
-                "signal-exit": "^3.0.0"
+                "currently-unhandled": "0.4.1",
+                "signal-exit": "3.0.2"
             }
         },
         "lower-case": {
@@ -10099,8 +9824,8 @@
             "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
             "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "macos-release": {
@@ -10115,7 +9840,7 @@
             "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
             "dev": true,
             "requires": {
-                "vlq": "^0.2.1"
+                "vlq": "0.2.3"
             }
         },
         "make-dir": {
@@ -10124,7 +9849,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -10159,7 +9884,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "math-random": {
@@ -10172,8 +9897,8 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             },
             "dependencies": {
                 "hash-base": {
@@ -10181,8 +9906,8 @@
                     "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
                     "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
                     "requires": {
-                        "inherits": "^2.0.1",
-                        "safe-buffer": "^5.0.1"
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -10199,7 +9924,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.1.0"
             }
         },
         "memory-fs": {
@@ -10208,8 +9933,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
+                "errno": "0.1.4",
+                "readable-stream": "2.3.3"
             },
             "dependencies": {
                 "isarray": {
@@ -10224,13 +9949,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -10239,7 +9964,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -10250,16 +9975,16 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "^2.0.0",
-                "decamelize": "^1.1.2",
-                "loud-rejection": "^1.0.0",
-                "map-obj": "^1.0.1",
-                "minimist": "^1.1.3",
-                "normalize-package-data": "^2.3.4",
-                "object-assign": "^4.0.1",
-                "read-pkg-up": "^1.0.1",
-                "redent": "^1.0.0",
-                "trim-newlines": "^1.0.0"
+                "camelcase-keys": "2.1.0",
+                "decamelize": "1.2.0",
+                "loud-rejection": "1.6.0",
+                "map-obj": "1.0.1",
+                "minimist": "1.2.0",
+                "normalize-package-data": "2.4.0",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "redent": "1.0.0",
+                "trim-newlines": "1.0.0"
             }
         },
         "merge-descriptors": {
@@ -10279,19 +10004,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
             }
         },
         "miller-rabin": {
@@ -10299,8 +10024,8 @@
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "requires": {
-                "bn.js": "^4.0.0",
-                "brorand": "^1.0.1"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime": {
@@ -10319,7 +10044,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "requires": {
-                "mime-db": "~1.30.0"
+                "mime-db": "1.30.0"
             }
         },
         "mimic-fn": {
@@ -10343,7 +10068,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.8"
             }
         },
         "minimist": {
@@ -10357,16 +10082,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.2",
+                "duplexify": "3.6.1",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.3",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.5.1",
+                "stream-each": "1.2.3",
+                "through2": "2.0.3"
             },
             "dependencies": {
                 "isarray": {
@@ -10387,13 +10112,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -10402,7 +10127,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 },
                 "through2": {
@@ -10411,8 +10136,8 @@
                     "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "^2.1.5",
-                        "xtend": "~4.0.1"
+                        "readable-stream": "2.3.6",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -10423,8 +10148,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -10433,7 +10158,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -10444,8 +10169,8 @@
             "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
             "dev": true,
             "requires": {
-                "for-in": "^0.1.3",
-                "is-extendable": "^0.1.1"
+                "for-in": "0.1.8",
+                "is-extendable": "0.1.1"
             },
             "dependencies": {
                 "for-in": {
@@ -10481,7 +10206,7 @@
             "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
             "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
             "requires": {
-                "moment": ">= 2.9.0"
+                "moment": "2.22.2"
             }
         },
         "move-concurrently": {
@@ -10490,12 +10215,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "ms": {
@@ -10510,8 +10235,8 @@
             "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
             "dev": true,
             "requires": {
-                "dns-packet": "^1.3.1",
-                "thunky": "^1.0.2"
+                "dns-packet": "1.3.1",
+                "thunky": "1.0.3"
             }
         },
         "multicast-dns-service-types": {
@@ -10531,17 +10256,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.0",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -10562,8 +10287,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
+                        "is-descriptor": "1.0.2",
+                        "isobject": "3.0.1"
                     }
                 },
                 "extend-shallow": {
@@ -10572,8 +10297,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -10582,7 +10307,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 },
                 "isobject": {
@@ -10616,7 +10341,7 @@
             "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-1.6.0.tgz",
             "integrity": "sha512-9w0WH69x5/nuqC1og2WaY39NbaBqTGIP1+5gZaH7/KPN6UEPonNg/pYnsIVklLj1DWPWXKa8+XXIJZ1jy5nLxg==",
             "requires": {
-                "chart.js": "^2.6.0"
+                "chart.js": "2.7.2"
             }
         },
         "ngx-filter-pipe": {
@@ -10630,7 +10355,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "^1.1.1"
+                "lower-case": "1.1.4"
             }
         },
         "node-forge": {
@@ -10644,19 +10369,19 @@
             "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
             "dev": true,
             "requires": {
-                "fstream": "^1.0.0",
-                "glob": "^7.0.3",
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.0",
-                "nopt": "2 || 3",
-                "npmlog": "0 || 1 || 2 || 3 || 4",
-                "osenv": "0",
-                "request": "2",
-                "rimraf": "2",
-                "semver": "~5.3.0",
-                "tar": "^2.0.0",
-                "which": "1"
+                "fstream": "1.0.11",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "npmlog": "4.1.2",
+                "osenv": "0.1.4",
+                "request": "2.88.0",
+                "rimraf": "2.6.2",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "which": "1.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -10673,28 +10398,28 @@
             "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
             "dev": true,
             "requires": {
-                "assert": "^1.1.1",
-                "browserify-zlib": "^0.1.4",
-                "buffer": "^4.3.0",
-                "console-browserify": "^1.1.0",
-                "constants-browserify": "^1.0.0",
-                "crypto-browserify": "^3.11.0",
-                "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
+                "assert": "1.4.1",
+                "browserify-zlib": "0.1.4",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.11.0",
+                "domain-browser": "1.1.7",
+                "events": "1.1.1",
                 "https-browserify": "0.0.1",
-                "os-browserify": "^0.2.0",
+                "os-browserify": "0.2.1",
                 "path-browserify": "0.0.0",
-                "process": "^0.11.0",
-                "punycode": "^1.2.4",
-                "querystring-es3": "^0.2.0",
-                "readable-stream": "^2.0.5",
-                "stream-browserify": "^2.0.1",
-                "stream-http": "^2.3.1",
-                "string_decoder": "^0.10.25",
-                "timers-browserify": "^2.0.2",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.3",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.7.2",
+                "string_decoder": "0.10.31",
+                "timers-browserify": "2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "^0.11.0",
-                "util": "^0.10.3",
+                "url": "0.11.0",
+                "util": "0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -10710,13 +10435,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     },
                     "dependencies": {
                         "string_decoder": {
@@ -10725,7 +10450,7 @@
                             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.1"
                             }
                         }
                     }
@@ -10744,25 +10469,25 @@
             "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
             "dev": true,
             "requires": {
-                "async-foreach": "^0.1.3",
-                "chalk": "^1.1.1",
-                "cross-spawn": "^3.0.0",
-                "gaze": "^1.0.0",
-                "get-stdin": "^4.0.1",
-                "glob": "^7.0.3",
-                "in-publish": "^2.0.0",
-                "lodash.assign": "^4.2.0",
-                "lodash.clonedeep": "^4.3.2",
-                "lodash.mergewith": "^4.6.0",
-                "meow": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "nan": "^2.10.0",
-                "node-gyp": "^3.3.1",
-                "npmlog": "^4.0.0",
-                "request": "~2.79.0",
-                "sass-graph": "^2.2.4",
-                "stdout-stream": "^1.4.0",
-                "true-case-path": "^1.0.2"
+                "async-foreach": "0.1.3",
+                "chalk": "1.1.3",
+                "cross-spawn": "3.0.1",
+                "gaze": "1.1.2",
+                "get-stdin": "4.0.1",
+                "glob": "7.1.3",
+                "in-publish": "2.0.0",
+                "lodash.assign": "4.2.0",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.mergewith": "4.6.0",
+                "meow": "3.7.0",
+                "mkdirp": "0.5.1",
+                "nan": "2.11.1",
+                "node-gyp": "3.6.2",
+                "npmlog": "4.1.2",
+                "request": "2.79.0",
+                "sass-graph": "2.2.4",
+                "stdout-stream": "1.4.0",
+                "true-case-path": "1.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10795,11 +10520,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "cross-spawn": {
@@ -10808,8 +10533,8 @@
                     "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.1",
+                        "which": "1.3.0"
                     }
                 },
                 "form-data": {
@@ -10818,9 +10543,9 @@
                     "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.5",
-                        "mime-types": "^2.1.12"
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.17"
                     }
                 },
                 "har-validator": {
@@ -10829,10 +10554,10 @@
                     "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "^1.1.1",
-                        "commander": "^2.9.0",
-                        "is-my-json-valid": "^2.12.4",
-                        "pinkie-promise": "^2.0.0"
+                        "chalk": "1.1.3",
+                        "commander": "2.9.0",
+                        "is-my-json-valid": "2.17.1",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "http-signature": {
@@ -10841,9 +10566,9 @@
                     "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "^0.2.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.15.1"
                     }
                 },
                 "nan": {
@@ -10864,26 +10589,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "~0.6.0",
-                        "aws4": "^1.2.1",
-                        "caseless": "~0.11.0",
-                        "combined-stream": "~1.0.5",
-                        "extend": "~3.0.0",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.1.1",
-                        "har-validator": "~2.0.6",
-                        "hawk": "~3.1.3",
-                        "http-signature": "~1.1.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.7",
-                        "oauth-sign": "~0.8.1",
-                        "qs": "~6.3.0",
-                        "stringstream": "~0.0.4",
-                        "tough-cookie": "~2.3.0",
-                        "tunnel-agent": "~0.4.1",
-                        "uuid": "^3.0.0"
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.17",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.1.0"
                     }
                 },
                 "supports-color": {
@@ -10906,7 +10631,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
             }
         },
         "normalize-package-data": {
@@ -10915,10 +10640,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.4.1",
+                "validate-npm-package-license": "3.0.1"
             }
         },
         "normalize-path": {
@@ -10926,7 +10651,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "normalize-range": {
@@ -10941,7 +10666,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "npmlog": {
@@ -10950,10 +10675,10 @@
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
             }
         },
         "nth-check": {
@@ -10962,7 +10687,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0"
+                "boolbase": "1.0.0"
             }
         },
         "null-check": {
@@ -11007,9 +10732,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -11018,7 +10743,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -11027,7 +10752,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -11036,7 +10761,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "is-descriptor": {
@@ -11045,9 +10770,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -11072,7 +10797,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -11089,10 +10814,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.11"
             }
         },
         "object.omit": {
@@ -11100,8 +10825,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "object.pick": {
@@ -11110,7 +10835,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -11147,7 +10872,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "opn": {
@@ -11156,7 +10881,7 @@
             "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
             "dev": true,
             "requires": {
-                "is-wsl": "^1.1.0"
+                "is-wsl": "1.1.0"
             }
         },
         "optimist": {
@@ -11165,8 +10890,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -11183,7 +10908,7 @@
             "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
             "dev": true,
             "requires": {
-                "url-parse": "^1.4.3"
+                "url-parse": "1.4.3"
             }
         },
         "os-browserify": {
@@ -11204,7 +10929,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "^1.0.0"
+                "lcid": "1.0.0"
             }
         },
         "os-name": {
@@ -11213,8 +10938,8 @@
             "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
             "dev": true,
             "requires": {
-                "macos-release": "^1.0.0",
-                "win-release": "^1.0.0"
+                "macos-release": "1.1.0",
+                "win-release": "1.1.1"
             }
         },
         "os-tmpdir": {
@@ -11229,8 +10954,8 @@
             "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.0"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "p-finally": {
@@ -11251,7 +10976,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.1.0"
             }
         },
         "p-map": {
@@ -11272,9 +10997,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "isarray": {
@@ -11295,13 +11020,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -11310,7 +11035,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -11321,7 +11046,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "^2.2.0"
+                "no-case": "2.3.2"
             }
         },
         "parse-asn1": {
@@ -11329,11 +11054,11 @@
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "requires": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "asn1.js": "4.9.2",
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.14"
             }
         },
         "parse-glob": {
@@ -11341,10 +11066,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "parse-json": {
@@ -11353,7 +11078,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.1"
             }
         },
         "parse-passwd": {
@@ -11368,7 +11093,7 @@
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "dev": true,
             "requires": {
-                "better-assert": "~1.0.0"
+                "better-assert": "1.0.2"
             }
         },
         "parseuri": {
@@ -11377,7 +11102,7 @@
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "dev": true,
             "requires": {
-                "better-assert": "~1.0.0"
+                "better-assert": "1.0.2"
             }
         },
         "parseurl": {
@@ -11410,7 +11135,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "^2.0.0"
+                "pinkie-promise": "2.0.1"
             }
         },
         "path-is-absolute": {
@@ -11431,9 +11156,9 @@
             "dev": true
         },
         "path-parse": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "path-to-regexp": {
             "version": "1.7.0",
@@ -11449,9 +11174,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "pbkdf2": {
@@ -11459,11 +11184,11 @@
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
             "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.9"
             }
         },
         "pegjs": {
@@ -11494,7 +11219,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "pkg-dir": {
@@ -11503,7 +11228,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -11512,7 +11237,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 }
             }
@@ -11524,7 +11249,7 @@
             "requires": {
                 "base64-js": "1.1.2",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "0.1.x"
+                "xmldom": "0.1.27"
             },
             "dependencies": {
                 "base64-js": {
@@ -11540,9 +11265,9 @@
             "integrity": "sha512-KanzLOERzKoX3En5yTiV8K/arnU1ykYVokmtEn0PgCzqKZG9489tqW8ifp9+v3/VJZ5YDjvDt/PAP5WaPgk7FA==",
             "dev": true,
             "requires": {
-                "async": "^1.5.2",
-                "debug": "^2.2.0",
-                "mkdirp": "0.5.x"
+                "async": "1.5.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1"
             },
             "dependencies": {
                 "async": {
@@ -11565,9 +11290,9 @@
             "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
+                "chalk": "2.4.1",
+                "source-map": "0.6.1",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11576,7 +11301,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -11585,9 +11310,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -11608,7 +11333,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -11619,10 +11344,10 @@
             "integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
             "dev": true,
             "requires": {
-                "postcss": "^6.0.1",
-                "postcss-value-parser": "^3.2.3",
-                "read-cache": "^1.0.0",
-                "resolve": "^1.1.7"
+                "postcss": "6.0.23",
+                "postcss-value-parser": "3.3.0",
+                "read-cache": "1.0.0",
+                "resolve": "1.8.1"
             }
         },
         "postcss-load-config": {
@@ -11631,8 +11356,8 @@
             "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "^4.0.0",
-                "import-cwd": "^2.0.0"
+                "cosmiconfig": "4.0.0",
+                "import-cwd": "2.1.0"
             }
         },
         "postcss-loader": {
@@ -11641,10 +11366,10 @@
             "integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "postcss": "^6.0.0",
-                "postcss-load-config": "^2.0.0",
-                "schema-utils": "^0.4.0"
+                "loader-utils": "1.1.0",
+                "postcss": "6.0.23",
+                "postcss-load-config": "2.0.0",
+                "schema-utils": "0.4.7"
             }
         },
         "postcss-url": {
@@ -11653,11 +11378,11 @@
             "integrity": "sha512-QMV5mA+pCYZQcUEPQkmor9vcPQ2MT+Ipuu8qdi1gVxbNiIiErEGft+eny1ak19qALoBkccS5AHaCaCDzh7b9MA==",
             "dev": true,
             "requires": {
-                "mime": "^1.4.1",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.0",
-                "postcss": "^6.0.1",
-                "xxhashjs": "^0.2.1"
+                "mime": "1.4.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "postcss": "6.0.23",
+                "xxhashjs": "0.2.2"
             }
         },
         "postcss-value-parser": {
@@ -11677,8 +11402,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "^2.0.1",
-                "utila": "~0.4"
+                "renderkid": "2.0.2",
+                "utila": "0.4.0"
             }
         },
         "process": {
@@ -11699,7 +11424,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "asap": "~2.0.3"
+                "asap": "2.0.6"
             }
         },
         "promise-inflight": {
@@ -11714,22 +11439,22 @@
             "integrity": "sha512-ORey5ewQMYiXQxcQohsqEiKYOg/r5yJoJbt0tuROmmgajdg/CA3gTOZNIFJncUVMAJIk5YFqBBLUjKVmQO6tfA==",
             "dev": true,
             "requires": {
-                "@types/node": "^6.0.46",
-                "@types/q": "^0.0.32",
-                "@types/selenium-webdriver": "^3.0.0",
-                "blocking-proxy": "^1.0.0",
-                "browserstack": "^1.5.1",
-                "chalk": "^1.1.3",
-                "glob": "^7.0.3",
+                "@types/node": "6.14.0",
+                "@types/q": "0.0.32",
+                "@types/selenium-webdriver": "3.0.12",
+                "blocking-proxy": "1.0.1",
+                "browserstack": "1.5.1",
+                "chalk": "1.1.3",
+                "glob": "7.1.3",
                 "jasmine": "2.8.0",
-                "jasminewd2": "^2.1.0",
-                "optimist": "~0.6.0",
+                "jasminewd2": "2.2.0",
+                "optimist": "0.6.1",
                 "q": "1.4.1",
-                "saucelabs": "^1.5.0",
+                "saucelabs": "1.5.0",
                 "selenium-webdriver": "3.6.0",
-                "source-map-support": "~0.4.0",
+                "source-map-support": "0.4.18",
                 "webdriver-js-extender": "2.1.0",
-                "webdriver-manager": "^12.0.6"
+                "webdriver-manager": "12.1.0"
             },
             "dependencies": {
                 "@types/node": {
@@ -11750,7 +11475,7 @@
                     "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
                     "dev": true,
                     "requires": {
-                        "es6-promisify": "^5.0.0"
+                        "es6-promisify": "5.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -11770,11 +11495,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "combined-stream": {
@@ -11782,7 +11507,7 @@
                     "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
                     "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
                     "requires": {
-                        "delayed-stream": "~1.0.0"
+                        "delayed-stream": "1.0.0"
                     }
                 },
                 "debug": {
@@ -11791,7 +11516,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "del": {
@@ -11800,13 +11525,13 @@
                     "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
                     "dev": true,
                     "requires": {
-                        "globby": "^5.0.0",
-                        "is-path-cwd": "^1.0.0",
-                        "is-path-in-cwd": "^1.0.0",
-                        "object-assign": "^4.0.1",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0",
-                        "rimraf": "^2.2.8"
+                        "globby": "5.0.0",
+                        "is-path-cwd": "1.0.0",
+                        "is-path-in-cwd": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "rimraf": "2.6.2"
                     }
                 },
                 "extend": {
@@ -11819,9 +11544,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "requires": {
-                        "asynckit": "^0.4.0",
+                        "asynckit": "0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "^2.1.12"
+                        "mime-types": "2.1.20"
                     },
                     "dependencies": {
                         "combined-stream": {
@@ -11829,7 +11554,7 @@
                             "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
                             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
                             "requires": {
-                                "delayed-stream": "~1.0.0"
+                                "delayed-stream": "1.0.0"
                             }
                         }
                     }
@@ -11840,12 +11565,12 @@
                     "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                     "dev": true,
                     "requires": {
-                        "array-union": "^1.0.1",
-                        "arrify": "^1.0.0",
-                        "glob": "^7.0.3",
-                        "object-assign": "^4.0.1",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.1.3",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "har-validator": {
@@ -11853,8 +11578,8 @@
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
                     "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "requires": {
-                        "ajv": "^5.3.0",
-                        "har-schema": "^2.0.0"
+                        "ajv": "5.3.0",
+                        "har-schema": "2.0.0"
                     }
                 },
                 "https-proxy-agent": {
@@ -11863,8 +11588,8 @@
                     "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
                     "dev": true,
                     "requires": {
-                        "agent-base": "^4.1.0",
-                        "debug": "^3.1.0"
+                        "agent-base": "4.2.1",
+                        "debug": "3.2.6"
                     }
                 },
                 "jasmine": {
@@ -11873,9 +11598,9 @@
                     "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
                     "dev": true,
                     "requires": {
-                        "exit": "^0.1.2",
-                        "glob": "^7.0.6",
-                        "jasmine-core": "~2.8.0"
+                        "exit": "0.1.2",
+                        "glob": "7.1.3",
+                        "jasmine-core": "2.8.0"
                     },
                     "dependencies": {
                         "glob": {
@@ -11884,12 +11609,12 @@
                             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                             "dev": true,
                             "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
                             }
                         }
                     }
@@ -11916,7 +11641,7 @@
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
                     "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
                     "requires": {
-                        "mime-db": "~1.36.0"
+                        "mime-db": "1.36.0"
                     }
                 },
                 "ms": {
@@ -11937,7 +11662,7 @@
                     "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
                     "dev": true,
                     "requires": {
-                        "https-proxy-agent": "^2.2.1"
+                        "https-proxy-agent": "2.2.1"
                     }
                 },
                 "selenium-webdriver": {
@@ -11946,10 +11671,10 @@
                     "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
                     "dev": true,
                     "requires": {
-                        "jszip": "^3.1.3",
-                        "rimraf": "^2.5.4",
+                        "jszip": "3.1.5",
+                        "rimraf": "2.6.2",
                         "tmp": "0.0.30",
-                        "xml2js": "^0.4.17"
+                        "xml2js": "0.4.19"
                     }
                 },
                 "supports-color": {
@@ -11964,7 +11689,7 @@
                     "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "~1.0.1"
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "webdriver-manager": {
@@ -11973,17 +11698,17 @@
                     "integrity": "sha512-oEc5fmkpz6Yh6udhwir5m0eN5mgRPq9P/NU5YWuT3Up5slt6Zz+znhLU7q4+8rwCZz/Qq3Fgpr/4oao7NPCm2A==",
                     "dev": true,
                     "requires": {
-                        "adm-zip": "^0.4.9",
-                        "chalk": "^1.1.1",
-                        "del": "^2.2.0",
-                        "glob": "^7.0.3",
-                        "ini": "^1.3.4",
-                        "minimist": "^1.2.0",
-                        "q": "^1.4.1",
-                        "request": "^2.87.0",
-                        "rimraf": "^2.5.2",
-                        "semver": "^5.3.0",
-                        "xml2js": "^0.4.17"
+                        "adm-zip": "0.4.11",
+                        "chalk": "1.1.3",
+                        "del": "2.2.2",
+                        "glob": "7.1.3",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "q": "1.4.1",
+                        "request": "2.88.0",
+                        "rimraf": "2.6.2",
+                        "semver": "5.4.1",
+                        "xml2js": "0.4.19"
                     }
                 }
             }
@@ -11994,7 +11719,7 @@
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "dev": true,
             "requires": {
-                "forwarded": "~0.1.2",
+                "forwarded": "0.1.2",
                 "ipaddr.js": "1.8.0"
             }
         },
@@ -12026,11 +11751,11 @@
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
             "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
             "requires": {
-                "bn.js": "^4.1.0",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "parse-asn1": "^5.0.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "parse-asn1": "5.1.0",
+                "randombytes": "2.0.5"
             }
         },
         "pump": {
@@ -12039,8 +11764,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "pumpify": {
@@ -12049,9 +11774,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.6.1",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -12075,7 +11800,7 @@
             "resolved": "https://registry.npmjs.org/qrious/-/qrious-2.3.0.tgz",
             "integrity": "sha1-ynzmioIJmmepDkl59LHN9R7zJHU=",
             "requires": {
-                "canvas": "^1.6.5"
+                "canvas": "1.6.9"
             }
         },
         "qs": {
@@ -12107,9 +11832,9 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
             "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -12129,7 +11854,7 @@
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
             "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.1"
             }
         },
         "randomfill": {
@@ -12137,8 +11862,8 @@
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "requires": {
-                "randombytes": "^2.0.5",
-                "safe-buffer": "^5.1.0"
+                "randombytes": "2.0.5",
+                "safe-buffer": "5.1.1"
             }
         },
         "range-parser": {
@@ -12171,7 +11896,7 @@
             "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
             "dev": true,
             "requires": {
-                "pify": "^2.3.0"
+                "pify": "2.3.0"
             }
         },
         "read-pkg": {
@@ -12180,9 +11905,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
             }
         },
         "read-pkg-up": {
@@ -12191,8 +11916,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
             }
         },
         "readable-stream": {
@@ -12201,10 +11926,10 @@
             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
             }
         },
         "readdirp": {
@@ -12212,10 +11937,10 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "readable-stream": "^2.0.2",
-                "set-immediate-shim": "^1.0.1"
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.3",
+                "set-immediate-shim": "1.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -12228,13 +11953,13 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -12242,7 +11967,7 @@
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -12252,7 +11977,7 @@
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "requires": {
-                "resolve": "^1.1.6"
+                "resolve": "1.8.1"
             }
         },
         "redent": {
@@ -12261,8 +11986,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
+                "indent-string": "2.1.0",
+                "strip-indent": "1.0.1"
             }
         },
         "reflect-metadata": {
@@ -12281,7 +12006,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -12290,7 +12015,7 @@
             "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1"
+                "extend-shallow": "2.0.1"
             }
         },
         "relateurl": {
@@ -12310,11 +12035,11 @@
             "integrity": "sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==",
             "dev": true,
             "requires": {
-                "css-select": "^1.1.0",
-                "dom-converter": "~0.2",
-                "htmlparser2": "~3.3.0",
-                "strip-ansi": "^3.0.0",
-                "utila": "^0.4.0"
+                "css-select": "1.2.0",
+                "dom-converter": "0.2.0",
+                "htmlparser2": "3.3.0",
+                "strip-ansi": "3.0.1",
+                "utila": "0.4.0"
             }
         },
         "repeat-element": {
@@ -12333,7 +12058,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "^1.0.0"
+                "is-finite": "1.0.2"
             }
         },
         "request": {
@@ -12341,26 +12066,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.0",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.21",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "aws4": {
@@ -12373,7 +12098,7 @@
                     "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
                     "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
                     "requires": {
-                        "delayed-stream": "~1.0.0"
+                        "delayed-stream": "1.0.0"
                     }
                 },
                 "extend": {
@@ -12391,7 +12116,7 @@
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
                     "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
                     "requires": {
-                        "mime-db": "~1.37.0"
+                        "mime-db": "1.37.0"
                     }
                 },
                 "oauth-sign": {
@@ -12414,8 +12139,8 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.29",
+                        "punycode": "1.4.1"
                     }
                 },
                 "uuid": {
@@ -12450,11 +12175,11 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.6"
             }
         },
         "resolve-cwd": {
@@ -12463,7 +12188,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             }
         },
         "resolve-from": {
@@ -12496,7 +12221,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "dev": true,
             "requires": {
-                "align-text": "^0.1.1"
+                "align-text": "0.1.4"
             }
         },
         "rimraf": {
@@ -12505,7 +12230,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.3"
             }
         },
         "ripemd160": {
@@ -12513,8 +12238,8 @@
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
             "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
             "requires": {
-                "hash-base": "^2.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "2.0.2",
+                "inherits": "2.0.3"
             }
         },
         "rollup": {
@@ -12529,11 +12254,11 @@
             "integrity": "sha512-qK0+uhktmnAgZkHkqFuajNmPw93fjrO7+CysDaxWE5jrUR9XSlSvuao5ZJP+XizxA8weakhgYYBtbVz9SGBpjA==",
             "dev": true,
             "requires": {
-                "acorn": "^5.2.1",
-                "estree-walker": "^0.5.0",
-                "magic-string": "^0.22.4",
-                "resolve": "^1.4.0",
-                "rollup-pluginutils": "^2.0.1"
+                "acorn": "5.7.3",
+                "estree-walker": "0.5.2",
+                "magic-string": "0.22.4",
+                "resolve": "1.8.1",
+                "rollup-pluginutils": "2.3.3"
             },
             "dependencies": {
                 "acorn": {
@@ -12550,10 +12275,10 @@
             "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
             "dev": true,
             "requires": {
-                "browser-resolve": "^1.11.0",
-                "builtin-modules": "^1.1.0",
-                "is-module": "^1.0.0",
-                "resolve": "^1.1.6"
+                "browser-resolve": "1.11.2",
+                "builtin-modules": "1.1.1",
+                "is-module": "1.0.0",
+                "resolve": "1.8.1"
             }
         },
         "rollup-pluginutils": {
@@ -12562,8 +12287,8 @@
             "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
             "dev": true,
             "requires": {
-                "estree-walker": "^0.5.2",
-                "micromatch": "^2.3.11"
+                "estree-walker": "0.5.2",
+                "micromatch": "2.3.11"
             }
         },
         "run-queue": {
@@ -12572,7 +12297,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
             }
         },
         "rxjs": {
@@ -12600,7 +12325,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -12614,10 +12339,10 @@
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.0",
-                "lodash": "^4.0.0",
-                "scss-tokenizer": "^0.2.3",
-                "yargs": "^7.0.0"
+                "glob": "7.1.3",
+                "lodash": "4.17.11",
+                "scss-tokenizer": "0.2.3",
+                "yargs": "7.1.0"
             }
         },
         "sass-loader": {
@@ -12626,11 +12351,11 @@
             "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
             "dev": true,
             "requires": {
-                "clone-deep": "^2.0.1",
-                "loader-utils": "^1.0.1",
-                "lodash.tail": "^4.1.1",
-                "neo-async": "^2.5.0",
-                "pify": "^3.0.0"
+                "clone-deep": "2.0.2",
+                "loader-utils": "1.1.0",
+                "lodash.tail": "4.1.1",
+                "neo-async": "2.6.0",
+                "pify": "3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -12653,8 +12378,8 @@
             "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
             "dev": true,
             "requires": {
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0"
+                "ajv": "6.5.4",
+                "ajv-keywords": "3.2.0"
             },
             "dependencies": {
                 "ajv": {
@@ -12663,10 +12388,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "ajv-keywords": {
@@ -12700,8 +12425,8 @@
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "^2.1.8",
-                "source-map": "^0.4.2"
+                "js-base64": "2.3.2",
+                "source-map": "0.4.4"
             },
             "dependencies": {
                 "source-map": {
@@ -12710,7 +12435,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -12725,14 +12450,14 @@
             "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
             "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
             "requires": {
-                "bindings": "^1.2.1",
-                "bip66": "^1.1.3",
-                "bn.js": "^4.11.3",
-                "create-hash": "^1.1.2",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.2.3",
-                "nan": "^2.2.1",
-                "safe-buffer": "^5.1.0"
+                "bindings": "1.3.0",
+                "bip66": "1.1.5",
+                "bn.js": "4.11.8",
+                "create-hash": "1.1.3",
+                "drbg.js": "1.0.1",
+                "elliptic": "6.4.0",
+                "nan": "2.7.0",
+                "safe-buffer": "5.1.1"
             }
         },
         "select-hose": {
@@ -12769,7 +12494,7 @@
             "integrity": "sha512-d8fvGg5ycKAq0+I6nfWeCx6ffaWJCsBYU0H2Rq56+/zFePYfT8mXkB3tWBSjR5BerkHNZ5eTPIk1/LBYas35xQ==",
             "dev": true,
             "requires": {
-                "semver": "^5.0.0"
+                "semver": "5.4.1"
             }
         },
         "serialize-javascript": {
@@ -12784,13 +12509,13 @@
             "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.4",
+                "accepts": "1.3.4",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
-                "escape-html": "~1.0.3",
-                "http-errors": "~1.6.2",
-                "mime-types": "~2.1.17",
-                "parseurl": "~1.3.2"
+                "escape-html": "1.0.3",
+                "http-errors": "1.6.2",
+                "mime-types": "2.1.17",
+                "parseurl": "1.3.2"
             }
         },
         "serve-static": {
@@ -12799,9 +12524,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
                 "send": "0.16.2"
             },
             "dependencies": {
@@ -12824,18 +12549,18 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "depd": "~1.1.2",
-                        "destroy": "~1.0.4",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
+                        "depd": "1.1.2",
+                        "destroy": "1.0.4",
+                        "encodeurl": "1.0.2",
+                        "escape-html": "1.0.3",
+                        "etag": "1.8.1",
                         "fresh": "0.5.2",
-                        "http-errors": "~1.6.2",
+                        "http-errors": "1.6.2",
                         "mime": "1.4.1",
                         "ms": "2.0.0",
-                        "on-finished": "~2.3.0",
-                        "range-parser": "~1.2.0",
-                        "statuses": "~1.4.0"
+                        "on-finished": "2.3.0",
+                        "range-parser": "1.2.0",
+                        "statuses": "1.4.0"
                     }
                 },
                 "statuses": {
@@ -12868,10 +12593,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             }
         },
         "setimmediate": {
@@ -12891,8 +12616,8 @@
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
             "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
             }
         },
         "shallow-clone": {
@@ -12901,9 +12626,9 @@
             "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
             "dev": true,
             "requires": {
-                "is-extendable": "^0.1.1",
-                "kind-of": "^5.0.0",
-                "mixin-object": "^2.0.1"
+                "is-extendable": "0.1.1",
+                "kind-of": "5.1.0",
+                "mixin-object": "2.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -12920,7 +12645,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -12934,9 +12659,9 @@
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
             "requires": {
-                "glob": "^7.0.0",
-                "interpret": "^1.0.0",
-                "rechoir": "^0.6.2"
+                "glob": "7.1.3",
+                "interpret": "1.1.0",
+                "rechoir": "0.6.2"
             }
         },
         "signal-exit": {
@@ -12951,7 +12676,7 @@
             "integrity": "sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==",
             "dev": true,
             "requires": {
-                "debug": "^2.2.0"
+                "debug": "2.6.9"
             }
         },
         "simple-plist": {
@@ -12976,14 +12701,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -12992,7 +12717,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -13001,7 +12726,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13010,7 +12735,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -13021,7 +12746,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13030,7 +12755,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -13041,9 +12766,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
                     }
                 },
                 "kind-of": {
@@ -13060,9 +12785,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -13079,7 +12804,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             }
         },
         "sntp": {
@@ -13088,7 +12813,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "socket.io": {
@@ -13097,12 +12822,12 @@
             "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
             "dev": true,
             "requires": {
-                "debug": "~3.1.0",
-                "engine.io": "~3.2.0",
-                "has-binary2": "~1.0.2",
-                "socket.io-adapter": "~1.1.0",
+                "debug": "3.1.0",
+                "engine.io": "3.2.0",
+                "has-binary2": "1.0.3",
+                "socket.io-adapter": "1.1.1",
                 "socket.io-client": "2.1.1",
-                "socket.io-parser": "~3.2.0"
+                "socket.io-parser": "3.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -13132,15 +12857,15 @@
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
-                "engine.io-client": "~3.2.0",
-                "has-binary2": "~1.0.2",
+                "debug": "3.1.0",
+                "engine.io-client": "3.2.1",
+                "has-binary2": "1.0.3",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.2.0",
+                "socket.io-parser": "3.2.0",
                 "to-array": "0.1.4"
             },
             "dependencies": {
@@ -13162,7 +12887,7 @@
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
+                "debug": "3.1.0",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -13189,8 +12914,8 @@
             "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
             "dev": true,
             "requires": {
-                "faye-websocket": "^0.10.0",
-                "uuid": "^3.0.1"
+                "faye-websocket": "0.10.0",
+                "uuid": "3.1.0"
             }
         },
         "sockjs-client": {
@@ -13199,12 +12924,12 @@
             "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
             "dev": true,
             "requires": {
-                "debug": "^2.6.6",
+                "debug": "2.6.9",
                 "eventsource": "0.1.6",
-                "faye-websocket": "~0.11.0",
-                "inherits": "^2.0.1",
-                "json3": "^3.3.2",
-                "url-parse": "^1.1.8"
+                "faye-websocket": "0.11.1",
+                "inherits": "2.0.3",
+                "json3": "3.3.2",
+                "url-parse": "1.4.3"
             },
             "dependencies": {
                 "faye-websocket": {
@@ -13213,7 +12938,7 @@
                     "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
                     "dev": true,
                     "requires": {
-                        "websocket-driver": ">=0.5.1"
+                        "websocket-driver": "0.7.0"
                     }
                 }
             }
@@ -13236,11 +12961,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -13249,7 +12974,7 @@
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
             }
         },
         "source-map-url": {
@@ -13264,7 +12989,7 @@
             "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
             "dev": true,
             "requires": {
-                "spdx-license-ids": "^1.0.2"
+                "spdx-license-ids": "1.2.2"
             }
         },
         "spdx-expression-parse": {
@@ -13285,12 +13010,12 @@
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "dev": true,
             "requires": {
-                "debug": "^2.6.8",
-                "handle-thing": "^1.2.5",
-                "http-deceiver": "^1.2.7",
-                "safe-buffer": "^5.0.1",
-                "select-hose": "^2.0.0",
-                "spdy-transport": "^2.0.18"
+                "debug": "2.6.9",
+                "handle-thing": "1.2.5",
+                "http-deceiver": "1.2.7",
+                "safe-buffer": "5.1.1",
+                "select-hose": "2.0.0",
+                "spdy-transport": "2.1.0"
             }
         },
         "spdy-transport": {
@@ -13299,13 +13024,13 @@
             "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.8",
-                "detect-node": "^2.0.3",
-                "hpack.js": "^2.1.6",
-                "obuf": "^1.1.1",
-                "readable-stream": "^2.2.9",
-                "safe-buffer": "^5.0.1",
-                "wbuf": "^1.7.2"
+                "debug": "2.6.9",
+                "detect-node": "2.0.4",
+                "hpack.js": "2.1.6",
+                "obuf": "1.1.2",
+                "readable-stream": "2.3.6",
+                "safe-buffer": "5.1.1",
+                "wbuf": "1.7.3"
             },
             "dependencies": {
                 "isarray": {
@@ -13326,13 +13051,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13341,7 +13066,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -13352,7 +13077,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -13361,8 +13086,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -13371,7 +13096,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -13387,15 +13112,15 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
             "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "ssri": {
@@ -13404,7 +13129,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "static-extend": {
@@ -13413,8 +13138,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -13423,7 +13148,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -13432,7 +13157,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13441,7 +13166,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -13452,7 +13177,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13461,7 +13186,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -13472,9 +13197,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^0.1.6",
-                        "is-data-descriptor": "^0.1.4",
-                        "kind-of": "^5.0.0"
+                        "is-accessor-descriptor": "0.1.6",
+                        "is-data-descriptor": "0.1.4",
+                        "kind-of": "5.1.0"
                     }
                 },
                 "kind-of": {
@@ -13497,7 +13222,7 @@
             "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.3"
             },
             "dependencies": {
                 "isarray": {
@@ -13512,13 +13237,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13527,7 +13252,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -13538,8 +13263,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "^2.0.2"
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
             },
             "dependencies": {
                 "isarray": {
@@ -13554,13 +13279,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13569,7 +13294,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -13585,8 +13310,8 @@
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
             }
         },
         "stream-http": {
@@ -13595,11 +13320,11 @@
             "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "^3.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.2.6",
-                "to-arraybuffer": "^1.0.0",
-                "xtend": "^4.0.0"
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -13614,13 +13339,13 @@
                     "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.0.3",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13629,7 +13354,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -13646,10 +13371,10 @@
             "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
             "dev": true,
             "requires": {
-                "date-format": "^1.2.0",
-                "debug": "^3.1.0",
-                "mkdirp": "^0.5.1",
-                "readable-stream": "^2.3.0"
+                "date-format": "1.2.0",
+                "debug": "3.2.6",
+                "mkdirp": "0.5.1",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "debug": {
@@ -13658,7 +13383,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "isarray": {
@@ -13685,13 +13410,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -13700,7 +13425,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 }
             }
@@ -13722,9 +13447,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
             }
         },
         "string_decoder": {
@@ -13735,7 +13460,8 @@
         },
         "stringstream": {
             "version": "0.0.5",
-            "resolved": "",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
             "dev": true
         },
         "strip-ansi": {
@@ -13744,7 +13470,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -13753,7 +13479,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-eof": {
@@ -13768,7 +13494,7 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "^4.0.1"
+                "get-stdin": "4.0.1"
             }
         },
         "strip-json-comments": {
@@ -13783,8 +13509,8 @@
             "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2",
-                "schema-utils": "^0.3.0"
+                "loader-utils": "1.1.0",
+                "schema-utils": "0.3.0"
             },
             "dependencies": {
                 "schema-utils": {
@@ -13793,7 +13519,7 @@
                     "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
                     "dev": true,
                     "requires": {
-                        "ajv": "^5.0.0"
+                        "ajv": "5.3.0"
                     }
                 }
             }
@@ -13804,14 +13530,28 @@
             "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
             "dev": true,
             "requires": {
-                "css-parse": "1.7.x",
-                "debug": "*",
-                "glob": "7.0.x",
-                "mkdirp": "0.5.x",
-                "sax": "0.5.x",
-                "source-map": "0.1.x"
+                "css-parse": "1.7.0",
+                "debug": "2.6.9",
+                "glob": "7.0.6",
+                "mkdirp": "0.5.1",
+                "sax": "0.5.8",
+                "source-map": "0.1.43"
             },
             "dependencies": {
+                "glob": {
+                    "version": "7.0.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                    "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
                 "sax": {
                     "version": "0.5.8",
                     "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
@@ -13824,7 +13564,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -13835,9 +13575,9 @@
             "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2",
-                "lodash.clonedeep": "^4.5.0",
-                "when": "~3.6.x"
+                "loader-utils": "1.1.0",
+                "lodash.clonedeep": "4.5.0",
+                "when": "3.6.4"
             }
         },
         "supports-color": {
@@ -13846,7 +13586,7 @@
             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
             "dev": true,
             "requires": {
-                "has-flag": "^2.0.0"
+                "has-flag": "2.0.0"
             }
         },
         "sw-toolbox": {
@@ -13854,8 +13594,8 @@
             "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
             "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
             "requires": {
-                "path-to-regexp": "^1.0.1",
-                "serviceworker-cache-polyfill": "^4.0.0"
+                "path-to-regexp": "1.7.0",
+                "serviceworker-cache-polyfill": "4.0.0"
             }
         },
         "symbol-observable": {
@@ -13875,9 +13615,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "thunky": {
@@ -13898,7 +13638,7 @@
             "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
             "dev": true,
             "requires": {
-                "setimmediate": "^1.0.4"
+                "setimmediate": "1.0.5"
             }
         },
         "tiny-lr": {
@@ -13907,12 +13647,12 @@
             "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
             "dev": true,
             "requires": {
-                "body": "^5.1.0",
-                "debug": "^3.1.0",
-                "faye-websocket": "~0.10.0",
-                "livereload-js": "^2.3.0",
-                "object-assign": "^4.1.0",
-                "qs": "^6.4.0"
+                "body": "5.1.0",
+                "debug": "3.2.6",
+                "faye-websocket": "0.10.0",
+                "livereload-js": "2.3.0",
+                "object-assign": "4.1.1",
+                "qs": "6.5.1"
             },
             "dependencies": {
                 "debug": {
@@ -13921,7 +13661,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -13938,7 +13678,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-array": {
@@ -13965,7 +13705,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "to-regex": {
@@ -13974,10 +13714,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -13986,8 +13726,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
+                        "is-descriptor": "1.0.2",
+                        "isobject": "3.0.1"
                     }
                 },
                 "extend-shallow": {
@@ -13996,8 +13736,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -14006,7 +13746,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 },
                 "isobject": {
@@ -14021,8 +13761,8 @@
                     "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^3.0.2",
-                        "safe-regex": "^1.1.0"
+                        "extend-shallow": "3.0.2",
+                        "safe-regex": "1.1.0"
                     }
                 }
             }
@@ -14033,8 +13773,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -14043,7 +13783,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 }
             }
@@ -14065,7 +13805,7 @@
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "dev": true,
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             }
         },
         "tree-kill": {
@@ -14092,7 +13832,7 @@
             "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
             "dev": true,
             "requires": {
-                "glob": "^6.0.4"
+                "glob": "6.0.4"
             },
             "dependencies": {
                 "glob": {
@@ -14101,11 +13841,11 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -14116,16 +13856,16 @@
             "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.0",
-                "chalk": "^2.3.0",
-                "diff": "^3.1.0",
-                "make-error": "^1.1.1",
-                "minimist": "^1.2.0",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.5.0",
-                "tsconfig": "^7.0.0",
-                "v8flags": "^3.0.0",
-                "yn": "^2.0.0"
+                "arrify": "1.0.1",
+                "chalk": "2.3.0",
+                "diff": "3.5.0",
+                "make-error": "1.3.3",
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.5.9",
+                "tsconfig": "7.0.0",
+                "v8flags": "3.1.1",
+                "yn": "2.0.0"
             },
             "dependencies": {
                 "diff": {
@@ -14146,8 +13886,8 @@
                     "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
                     "dev": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
+                        "buffer-from": "1.1.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -14158,10 +13898,10 @@
             "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
             "dev": true,
             "requires": {
-                "@types/strip-bom": "^3.0.0",
+                "@types/strip-bom": "3.0.0",
                 "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "^3.0.0",
-                "strip-json-comments": "^2.0.0"
+                "strip-bom": "3.0.0",
+                "strip-json-comments": "2.0.1"
             },
             "dependencies": {
                 "strip-bom": {
@@ -14177,10 +13917,10 @@
             "resolved": "http://registry.npmjs.org/tsickle/-/tsickle-0.27.5.tgz",
             "integrity": "sha512-NP+CjM1EXza/M8mOXBLH3vkFEJiu1zfEAlC5WdJxHPn8l96QPz5eooP6uAgYtw1CcKfuSyIiheNUdKxtDWCNeg==",
             "requires": {
-                "minimist": "^1.2.0",
-                "mkdirp": "^0.5.1",
-                "source-map": "^0.6.0",
-                "source-map-support": "^0.5.0"
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map": "0.6.1",
+                "source-map-support": "0.5.9"
             },
             "dependencies": {
                 "source-map": {
@@ -14193,8 +13933,8 @@
                     "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
                     "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
+                        "buffer-from": "1.1.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -14210,18 +13950,18 @@
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.27.2"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.3.0",
+                "commander": "2.19.0",
+                "diff": "3.5.0",
+                "glob": "7.1.3",
+                "js-yaml": "3.7.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.8.1",
+                "semver": "5.4.1",
+                "tslib": "1.8.0",
+                "tsutils": "2.29.0"
             },
             "dependencies": {
                 "commander": {
@@ -14236,12 +13976,12 @@
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -14252,9 +13992,9 @@
             "integrity": "sha1-fDDniC8mvCdr/5HSOEl1xp2viLo=",
             "dev": true,
             "requires": {
-                "doctrine": "^0.7.2",
-                "tslib": "^1.0.0",
-                "tsutils": "^1.4.0"
+                "doctrine": "0.7.2",
+                "tslib": "1.8.0",
+                "tsutils": "1.9.1"
             },
             "dependencies": {
                 "tsutils": {
@@ -14271,7 +14011,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.3"
             },
             "dependencies": {
                 "tslib": {
@@ -14293,7 +14033,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "tweetnacl": {
@@ -14308,7 +14048,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.15"
+                "mime-types": "2.1.17"
             }
         },
         "typedarray": {
@@ -14318,15 +14058,39 @@
             "dev": true
         },
         "typeforce": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.15.1.tgz",
-            "integrity": "sha512-RYgFG+2GXx4V7guHOhW0cvryg/iWAoopbF/WlOI25YoV9rsOQ0E8bKfYAEZbJL0LJ8yVqcwp77tDG+oebBSNNw=="
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.16.0.tgz",
+            "integrity": "sha512-V60F7OHPH7vPlgIU73vYyeebKxWjQqCTlge+MvKlVn09PIhCOi/ZotowYdgREHB5S1dyHOr906ui6NheYXjlVQ=="
         },
         "typescript": {
             "version": "2.7.2",
             "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
             "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
             "dev": true
+        },
+        "uglify-es": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
+            "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
+            "dev": true,
+            "requires": {
+                "commander": "2.12.2",
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.12.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
         },
         "uglify-js": {
             "version": "3.3.9",
@@ -14335,8 +14099,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.13.0",
-                "source-map": "~0.6.1"
+                "commander": "2.13.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -14368,9 +14132,9 @@
             "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.6",
-                "uglify-js": "^2.8.29",
-                "webpack-sources": "^1.0.1"
+                "source-map": "0.5.7",
+                "uglify-js": "2.8.29",
+                "webpack-sources": "1.0.2"
             },
             "dependencies": {
                 "camelcase": {
@@ -14385,8 +14149,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -14396,9 +14160,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "source-map": "0.5.7",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
                     }
                 },
                 "yargs": {
@@ -14407,9 +14171,9 @@
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -14427,10 +14191,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "set-value": {
@@ -14439,10 +14203,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -14453,7 +14217,7 @@
             "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
             "dev": true,
             "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.1"
             }
         },
         "unique-slug": {
@@ -14462,7 +14226,7 @@
             "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
             "dev": true,
             "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
             }
         },
         "universalify": {
@@ -14488,8 +14252,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -14498,9 +14262,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -14552,7 +14316,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             },
             "dependencies": {
                 "punycode": {
@@ -14599,9 +14363,9 @@
             "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2",
-                "mime": "^1.4.1",
-                "schema-utils": "^0.3.0"
+                "loader-utils": "1.1.0",
+                "mime": "1.4.1",
+                "schema-utils": "0.3.0"
             },
             "dependencies": {
                 "schema-utils": {
@@ -14610,7 +14374,7 @@
                     "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
                     "dev": true,
                     "requires": {
-                        "ajv": "^5.0.0"
+                        "ajv": "5.3.0"
                     }
                 }
             }
@@ -14621,8 +14385,8 @@
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.1.0",
+                "requires-port": "1.0.0"
             }
         },
         "use": {
@@ -14637,8 +14401,8 @@
             "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
             "dev": true,
             "requires": {
-                "lru-cache": "2.2.x",
-                "tmp": "0.0.x"
+                "lru-cache": "2.2.4",
+                "tmp": "0.0.33"
             },
             "dependencies": {
                 "lru-cache": {
@@ -14695,7 +14459,7 @@
             "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -14704,8 +14468,8 @@
             "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
             "dev": true,
             "requires": {
-                "spdx-correct": "~1.0.0",
-                "spdx-expression-parse": "~1.0.0"
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
             }
         },
         "vary": {
@@ -14719,9 +14483,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vlq": {
@@ -14751,9 +14515,9 @@
             "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
             "dev": true,
             "requires": {
-                "async": "^2.1.2",
-                "chokidar": "^1.7.0",
-                "graceful-fs": "^4.1.2"
+                "async": "2.6.0",
+                "chokidar": "1.7.0",
+                "graceful-fs": "4.1.11"
             }
         },
         "wbuf": {
@@ -14762,7 +14526,7 @@
             "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
             "dev": true,
             "requires": {
-                "minimalistic-assert": "^1.0.0"
+                "minimalistic-assert": "1.0.0"
             }
         },
         "webdriver-js-extender": {
@@ -14771,8 +14535,8 @@
             "integrity": "sha512-lcUKrjbBfCK6MNsh7xaY2UAUmZwe+/ib03AjVOpFobX4O7+83BUveSrLfU0Qsyb1DaKJdQRbuU+kM9aZ6QUhiQ==",
             "dev": true,
             "requires": {
-                "@types/selenium-webdriver": "^3.0.0",
-                "selenium-webdriver": "^3.0.1"
+                "@types/selenium-webdriver": "3.0.12",
+                "selenium-webdriver": "3.6.0"
             },
             "dependencies": {
                 "selenium-webdriver": {
@@ -14781,10 +14545,10 @@
                     "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
                     "dev": true,
                     "requires": {
-                        "jszip": "^3.1.3",
-                        "rimraf": "^2.5.4",
+                        "jszip": "3.1.5",
+                        "rimraf": "2.6.2",
                         "tmp": "0.0.30",
-                        "xml2js": "^0.4.17"
+                        "xml2js": "0.4.19"
                     }
                 },
                 "tmp": {
@@ -14793,7 +14557,7 @@
                     "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "~1.0.1"
+                        "os-tmpdir": "1.0.2"
                     }
                 }
             }
@@ -14804,28 +14568,28 @@
             "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0",
-                "acorn-dynamic-import": "^2.0.0",
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "async": "^2.1.2",
-                "enhanced-resolve": "^3.4.0",
-                "escope": "^3.6.0",
-                "interpret": "^1.0.0",
-                "json-loader": "^0.5.4",
-                "json5": "^0.5.1",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^1.1.0",
-                "memory-fs": "~0.4.1",
-                "mkdirp": "~0.5.0",
-                "node-libs-browser": "^2.0.0",
-                "source-map": "^0.5.3",
-                "supports-color": "^4.2.1",
-                "tapable": "^0.2.7",
-                "uglifyjs-webpack-plugin": "^0.4.6",
-                "watchpack": "^1.4.0",
-                "webpack-sources": "^1.0.1",
-                "yargs": "^8.0.2"
+                "acorn": "5.7.3",
+                "acorn-dynamic-import": "2.0.2",
+                "ajv": "6.5.4",
+                "ajv-keywords": "3.2.0",
+                "async": "2.6.0",
+                "enhanced-resolve": "3.4.1",
+                "escope": "3.6.0",
+                "interpret": "1.1.0",
+                "json-loader": "0.5.7",
+                "json5": "0.5.1",
+                "loader-runner": "2.3.0",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "mkdirp": "0.5.1",
+                "node-libs-browser": "2.0.0",
+                "source-map": "0.5.7",
+                "supports-color": "4.5.0",
+                "tapable": "0.2.8",
+                "uglifyjs-webpack-plugin": "0.4.6",
+                "watchpack": "1.4.0",
+                "webpack-sources": "1.0.2",
+                "yargs": "8.0.2"
             },
             "dependencies": {
                 "acorn": {
@@ -14840,10 +14604,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "ajv-keywords": {
@@ -14876,7 +14640,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -14897,10 +14661,10 @@
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^2.2.0",
-                        "pify": "^2.0.0",
-                        "strip-bom": "^3.0.0"
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "os-locale": {
@@ -14909,9 +14673,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                     }
                 },
                 "path-type": {
@@ -14920,7 +14684,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "^2.0.0"
+                        "pify": "2.3.0"
                     }
                 },
                 "read-pkg": {
@@ -14929,9 +14693,9 @@
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^2.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^2.0.0"
+                        "load-json-file": "2.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "2.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -14940,8 +14704,8 @@
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                     "dev": true,
                     "requires": {
-                        "find-up": "^2.0.0",
-                        "read-pkg": "^2.0.0"
+                        "find-up": "2.1.0",
+                        "read-pkg": "2.0.0"
                     }
                 },
                 "string-width": {
@@ -14950,8 +14714,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -14960,7 +14724,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "strip-bom": {
@@ -14981,19 +14745,19 @@
                     "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "read-pkg-up": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^7.0.0"
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -15002,7 +14766,7 @@
                     "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -15013,11 +14777,11 @@
             "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
             "dev": true,
             "requires": {
-                "memory-fs": "~0.4.1",
-                "mime": "^1.5.0",
-                "path-is-absolute": "^1.0.0",
-                "range-parser": "^1.0.3",
-                "time-stamp": "^2.0.0"
+                "memory-fs": "0.4.1",
+                "mime": "1.6.0",
+                "path-is-absolute": "1.0.1",
+                "range-parser": "1.2.0",
+                "time-stamp": "2.1.0"
             },
             "dependencies": {
                 "mime": {
@@ -15035,30 +14799,30 @@
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "array-includes": "^3.0.3",
-                "bonjour": "^3.5.0",
-                "chokidar": "^2.0.0",
-                "compression": "^1.5.2",
-                "connect-history-api-fallback": "^1.3.0",
-                "debug": "^3.1.0",
-                "del": "^3.0.0",
-                "express": "^4.16.2",
-                "html-entities": "^1.2.0",
-                "http-proxy-middleware": "~0.17.4",
-                "import-local": "^1.0.0",
+                "array-includes": "3.0.3",
+                "bonjour": "3.5.0",
+                "chokidar": "2.0.4",
+                "compression": "1.7.3",
+                "connect-history-api-fallback": "1.5.0",
+                "debug": "3.2.6",
+                "del": "3.0.0",
+                "express": "4.16.4",
+                "html-entities": "1.2.1",
+                "http-proxy-middleware": "0.17.4",
+                "import-local": "1.0.0",
                 "internal-ip": "1.2.0",
-                "ip": "^1.1.5",
-                "killable": "^1.0.0",
-                "loglevel": "^1.4.1",
-                "opn": "^5.1.0",
-                "portfinder": "^1.0.9",
-                "selfsigned": "^1.9.1",
-                "serve-index": "^1.7.2",
+                "ip": "1.1.5",
+                "killable": "1.0.1",
+                "loglevel": "1.6.1",
+                "opn": "5.1.0",
+                "portfinder": "1.0.18",
+                "selfsigned": "1.10.4",
+                "serve-index": "1.9.1",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.1.5",
-                "spdy": "^3.4.1",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^5.1.0",
+                "spdy": "3.4.7",
+                "strip-ansi": "3.0.1",
+                "supports-color": "5.5.0",
                 "webpack-dev-middleware": "1.12.2",
                 "yargs": "6.6.0"
             },
@@ -15069,8 +14833,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "^3.1.4",
-                        "normalize-path": "^2.1.1"
+                        "micromatch": "3.1.10",
+                        "normalize-path": "2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -15091,16 +14855,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.2",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -15109,7 +14873,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -15126,19 +14890,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.0",
-                        "braces": "^2.3.0",
-                        "fsevents": "^1.2.2",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "lodash.debounce": "^4.0.8",
-                        "normalize-path": "^2.1.1",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0",
-                        "upath": "^1.0.5"
+                        "anymatch": "2.0.0",
+                        "async-each": "1.0.1",
+                        "braces": "2.3.2",
+                        "fsevents": "1.2.4",
+                        "glob-parent": "3.1.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "4.0.0",
+                        "lodash.debounce": "4.0.8",
+                        "normalize-path": "2.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0",
+                        "upath": "1.1.0"
                     }
                 },
                 "debug": {
@@ -15147,7 +14911,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     },
                     "dependencies": {
                         "ms": {
@@ -15164,8 +14928,8 @@
                     "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.2",
-                        "isobject": "^3.0.1"
+                        "is-descriptor": "1.0.2",
+                        "isobject": "3.0.1"
                     }
                 },
                 "expand-brackets": {
@@ -15174,13 +14938,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "debug": {
@@ -15198,7 +14962,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -15207,7 +14971,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-descriptor": {
@@ -15216,9 +14980,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
                             }
                         },
                         "kind-of": {
@@ -15235,8 +14999,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "^1.0.0",
-                        "is-extendable": "^1.0.1"
+                        "assign-symbols": "1.0.0",
+                        "is-extendable": "1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -15245,7 +15009,7 @@
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "^2.0.4"
+                                "is-plain-object": "2.0.4"
                             }
                         }
                     }
@@ -15256,14 +15020,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -15272,7 +15036,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -15281,7 +15045,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -15292,10 +15056,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -15304,7 +15068,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -15316,8 +15080,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "nan": "^2.9.2",
-                        "node-pre-gyp": "^0.10.0"
+                        "nan": "2.11.1",
+                        "node-pre-gyp": "0.10.0"
                     },
                     "dependencies": {
                         "abbrev": {
@@ -15343,8 +15107,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "delegates": "^1.0.0",
-                                "readable-stream": "^2.0.6"
+                                "delegates": "1.0.0",
+                                "readable-stream": "2.3.6"
                             }
                         },
                         "balanced-match": {
@@ -15357,7 +15121,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "balanced-match": "^1.0.0",
+                                "balanced-match": "1.0.0",
                                 "concat-map": "0.0.1"
                             }
                         },
@@ -15421,7 +15185,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "minipass": "^2.2.1"
+                                "minipass": "2.2.4"
                             }
                         },
                         "fs.realpath": {
@@ -15436,14 +15200,14 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "aproba": "^1.0.3",
-                                "console-control-strings": "^1.0.0",
-                                "has-unicode": "^2.0.0",
-                                "object-assign": "^4.1.0",
-                                "signal-exit": "^3.0.0",
-                                "string-width": "^1.0.1",
-                                "strip-ansi": "^3.0.1",
-                                "wide-align": "^1.1.0"
+                                "aproba": "1.2.0",
+                                "console-control-strings": "1.1.0",
+                                "has-unicode": "2.0.1",
+                                "object-assign": "4.1.1",
+                                "signal-exit": "3.0.2",
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1",
+                                "wide-align": "1.1.2"
                             }
                         },
                         "glob": {
@@ -15452,12 +15216,12 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "fs.realpath": "^1.0.0",
-                                "inflight": "^1.0.4",
-                                "inherits": "2",
-                                "minimatch": "^3.0.4",
-                                "once": "^1.3.0",
-                                "path-is-absolute": "^1.0.0"
+                                "fs.realpath": "1.0.0",
+                                "inflight": "1.0.6",
+                                "inherits": "2.0.3",
+                                "minimatch": "3.0.4",
+                                "once": "1.4.0",
+                                "path-is-absolute": "1.0.1"
                             }
                         },
                         "has-unicode": {
@@ -15472,7 +15236,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "safer-buffer": "^2.1.0"
+                                "safer-buffer": "2.1.2"
                             }
                         },
                         "ignore-walk": {
@@ -15481,7 +15245,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "minimatch": "^3.0.4"
+                                "minimatch": "3.0.4"
                             }
                         },
                         "inflight": {
@@ -15490,8 +15254,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "once": "^1.3.0",
-                                "wrappy": "1"
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
                             }
                         },
                         "inherits": {
@@ -15510,7 +15274,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                             }
                         },
                         "isarray": {
@@ -15524,7 +15288,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "brace-expansion": "^1.1.7"
+                                "brace-expansion": "1.1.11"
                             }
                         },
                         "minimist": {
@@ -15537,8 +15301,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "^5.1.1",
-                                "yallist": "^3.0.0"
+                                "safe-buffer": "5.1.1",
+                                "yallist": "3.0.2"
                             }
                         },
                         "minizlib": {
@@ -15547,7 +15311,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "minipass": "^2.2.1"
+                                "minipass": "2.2.4"
                             }
                         },
                         "mkdirp": {
@@ -15570,9 +15334,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "debug": "^2.1.2",
-                                "iconv-lite": "^0.4.4",
-                                "sax": "^1.2.4"
+                                "debug": "2.6.9",
+                                "iconv-lite": "0.4.21",
+                                "sax": "1.2.4"
                             }
                         },
                         "node-pre-gyp": {
@@ -15581,16 +15345,16 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "detect-libc": "^1.0.2",
-                                "mkdirp": "^0.5.1",
-                                "needle": "^2.2.0",
-                                "nopt": "^4.0.1",
-                                "npm-packlist": "^1.1.6",
-                                "npmlog": "^4.0.2",
-                                "rc": "^1.1.7",
-                                "rimraf": "^2.6.1",
-                                "semver": "^5.3.0",
-                                "tar": "^4"
+                                "detect-libc": "1.0.3",
+                                "mkdirp": "0.5.1",
+                                "needle": "2.2.0",
+                                "nopt": "4.0.1",
+                                "npm-packlist": "1.1.10",
+                                "npmlog": "4.1.2",
+                                "rc": "1.2.7",
+                                "rimraf": "2.6.2",
+                                "semver": "5.5.0",
+                                "tar": "4.4.1"
                             }
                         },
                         "nopt": {
@@ -15599,8 +15363,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "abbrev": "1",
-                                "osenv": "^0.1.4"
+                                "abbrev": "1.1.1",
+                                "osenv": "0.1.5"
                             }
                         },
                         "npm-bundled": {
@@ -15615,8 +15379,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "ignore-walk": "^3.0.1",
-                                "npm-bundled": "^1.0.1"
+                                "ignore-walk": "3.0.1",
+                                "npm-bundled": "1.0.3"
                             }
                         },
                         "npmlog": {
@@ -15625,10 +15389,10 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "are-we-there-yet": "~1.1.2",
-                                "console-control-strings": "~1.1.0",
-                                "gauge": "~2.7.3",
-                                "set-blocking": "~2.0.0"
+                                "are-we-there-yet": "1.1.4",
+                                "console-control-strings": "1.1.0",
+                                "gauge": "2.7.4",
+                                "set-blocking": "2.0.0"
                             }
                         },
                         "number-is-nan": {
@@ -15647,7 +15411,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "wrappy": "1"
+                                "wrappy": "1.0.2"
                             }
                         },
                         "os-homedir": {
@@ -15668,8 +15432,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "os-homedir": "^1.0.0",
-                                "os-tmpdir": "^1.0.0"
+                                "os-homedir": "1.0.2",
+                                "os-tmpdir": "1.0.2"
                             }
                         },
                         "path-is-absolute": {
@@ -15690,10 +15454,10 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "deep-extend": "^0.5.1",
-                                "ini": "~1.3.0",
-                                "minimist": "^1.2.0",
-                                "strip-json-comments": "~2.0.1"
+                                "deep-extend": "0.5.1",
+                                "ini": "1.3.5",
+                                "minimist": "1.2.0",
+                                "strip-json-comments": "2.0.1"
                             },
                             "dependencies": {
                                 "minimist": {
@@ -15710,13 +15474,13 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "core-util-is": "~1.0.0",
-                                "inherits": "~2.0.3",
-                                "isarray": "~1.0.0",
-                                "process-nextick-args": "~2.0.0",
-                                "safe-buffer": "~5.1.1",
-                                "string_decoder": "~1.1.1",
-                                "util-deprecate": "~1.0.1"
+                                "core-util-is": "1.0.2",
+                                "inherits": "2.0.3",
+                                "isarray": "1.0.0",
+                                "process-nextick-args": "2.0.0",
+                                "safe-buffer": "5.1.1",
+                                "string_decoder": "1.1.1",
+                                "util-deprecate": "1.0.2"
                             }
                         },
                         "rimraf": {
@@ -15725,7 +15489,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "glob": "^7.0.5"
+                                "glob": "7.1.2"
                             }
                         },
                         "safe-buffer": {
@@ -15768,9 +15532,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         },
                         "string_decoder": {
@@ -15779,7 +15543,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "safe-buffer": "~5.1.0"
+                                "safe-buffer": "5.1.1"
                             }
                         },
                         "strip-ansi": {
@@ -15787,7 +15551,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                             }
                         },
                         "strip-json-comments": {
@@ -15802,13 +15566,13 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "chownr": "^1.0.1",
-                                "fs-minipass": "^1.2.5",
-                                "minipass": "^2.2.4",
-                                "minizlib": "^1.1.0",
-                                "mkdirp": "^0.5.0",
-                                "safe-buffer": "^5.1.1",
-                                "yallist": "^3.0.2"
+                                "chownr": "1.0.1",
+                                "fs-minipass": "1.2.5",
+                                "minipass": "2.2.4",
+                                "minizlib": "1.1.0",
+                                "mkdirp": "0.5.1",
+                                "safe-buffer": "5.1.1",
+                                "yallist": "3.0.2"
                             }
                         },
                         "util-deprecate": {
@@ -15823,7 +15587,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "string-width": "^1.0.2"
+                                "string-width": "1.0.2"
                             }
                         },
                         "wrappy": {
@@ -15844,8 +15608,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
+                        "is-glob": "3.1.0",
+                        "path-dirname": "1.0.2"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -15854,7 +15618,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "^2.1.0"
+                                "is-extglob": "2.1.1"
                             }
                         }
                     }
@@ -15871,7 +15635,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -15880,7 +15644,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -15891,7 +15655,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -15900,7 +15664,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -15917,7 +15681,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "is-number": {
@@ -15926,7 +15690,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -15935,7 +15699,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -15958,19 +15722,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.13",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.0",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 },
                 "nan": {
@@ -15986,7 +15750,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "yargs": {
@@ -15995,19 +15759,19 @@
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^4.2.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "4.2.1"
                     }
                 },
                 "yargs-parser": {
@@ -16016,7 +15780,7 @@
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "3.0.0"
                     }
                 }
             }
@@ -16027,10 +15791,10 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.1.0",
-                "log-symbols": "^2.1.0",
-                "loglevelnext": "^1.0.1",
-                "uuid": "^3.1.0"
+                "chalk": "2.3.0",
+                "log-symbols": "2.2.0",
+                "loglevelnext": "1.0.5",
+                "uuid": "3.1.0"
             }
         },
         "webpack-merge": {
@@ -16039,7 +15803,7 @@
             "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.5"
+                "lodash": "4.17.11"
             }
         },
         "webpack-sources": {
@@ -16048,8 +15812,8 @@
             "integrity": "sha512-Y7UddMCv6dGjy81nBv6nuQeFFIt5aalHm7uyDsAsW86nZwfOVPGRr3XMjEQLaT+WKo8rlzhC9qtbJvYKLtAwaw==",
             "dev": true,
             "requires": {
-                "source-list-map": "^2.0.0",
-                "source-map": "~0.6.1"
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -16066,7 +15830,7 @@
             "integrity": "sha512-bdMR4DRbINUFt+QhNfBFHURnCzT8mtHjXiclQWX/aXBpu2pM4nOb2qViyt84ZSFrVKEXkAbmz7mSoZQH/08xFg==",
             "dev": true,
             "requires": {
-                "webpack-sources": "^1.3.0"
+                "webpack-sources": "1.3.0"
             },
             "dependencies": {
                 "source-map": {
@@ -16081,8 +15845,8 @@
                     "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
                     "dev": true,
                     "requires": {
-                        "source-list-map": "^2.0.0",
-                        "source-map": "~0.6.1"
+                        "source-list-map": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -16092,7 +15856,7 @@
             "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-3.4.3.tgz",
             "integrity": "sha1-tjYGLu6abvFYrNDYUBtnhDS1bxY=",
             "requires": {
-                "sdp": "^1.5.0"
+                "sdp": "1.5.4"
             }
         },
         "websocket-driver": {
@@ -16101,8 +15865,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": ">=0.4.0",
-                "websocket-extensions": ">=0.1.1"
+                "http-parser-js": "0.4.9",
+                "websocket-extensions": "0.1.3"
             }
         },
         "websocket-extensions": {
@@ -16123,7 +15887,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -16138,7 +15902,7 @@
             "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.2"
+                "string-width": "1.0.2"
             }
         },
         "wif": {
@@ -16146,7 +15910,7 @@
             "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
             "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
             "requires": {
-                "bs58check": "<3.0.0"
+                "bs58check": "2.0.2"
             }
         },
         "win-release": {
@@ -16155,7 +15919,7 @@
             "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
             "dev": true,
             "requires": {
-                "semver": "^5.0.1"
+                "semver": "5.4.1"
             }
         },
         "window-size": {
@@ -16176,7 +15940,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "~0.1.7"
+                "errno": "0.1.7"
             },
             "dependencies": {
                 "errno": {
@@ -16185,7 +15949,7 @@
                     "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
                     "dev": true,
                     "requires": {
-                        "prr": "~1.0.1"
+                        "prr": "1.0.1"
                     }
                 },
                 "prr": {
@@ -16202,8 +15966,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             }
         },
         "wrappy": {
@@ -16217,9 +15981,9 @@
             "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0",
-                "safe-buffer": "~5.1.0",
-                "ultron": "~1.1.0"
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.0"
             }
         },
         "xcode": {
@@ -16227,8 +15991,8 @@
             "resolved": "https://registry.npmjs.org/xcode/-/xcode-1.0.0.tgz",
             "integrity": "sha1-4fWxRDJF3tOMGAeW3xoQ/e2ghOw=",
             "requires": {
-                "pegjs": "^0.10.0",
-                "simple-plist": "^0.2.1",
+                "pegjs": "0.10.0",
+                "simple-plist": "0.2.1",
                 "uuid": "3.0.1"
             },
             "dependencies": {
@@ -16245,8 +16009,8 @@
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "dev": true,
             "requires": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "sax": "1.2.4",
+                "xmlbuilder": "9.0.7"
             },
             "dependencies": {
                 "xmlbuilder": {
@@ -16285,7 +16049,7 @@
             "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
             "dev": true,
             "requires": {
-                "cuint": "^0.2.2"
+                "cuint": "0.2.2"
             }
         },
         "y18n": {
@@ -16306,19 +16070,19 @@
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
             "dev": true,
             "requires": {
-                "camelcase": "^3.0.0",
-                "cliui": "^3.2.0",
-                "decamelize": "^1.1.1",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^1.4.0",
-                "read-pkg-up": "^1.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^1.0.2",
-                "which-module": "^1.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^5.0.0"
+                "camelcase": "3.0.0",
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "5.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -16335,7 +16099,7 @@
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "dev": true,
             "requires": {
-                "camelcase": "^3.0.0"
+                "camelcase": "3.0.0"
             },
             "dependencies": {
                 "camelcase": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-inappbrowser": "^3.0.0",
     "cordova-plugin-ionic-keyboard": "^2.1.3",
-    "cordova-plugin-ionic-webview": "^2.2.0",
     "cordova-plugin-local-notification": "^0.9.0-beta.2",
     "cordova-plugin-network-information": "^2.0.1",
     "cordova-plugin-qrscanner": "^2.6.0",
@@ -92,7 +91,7 @@
     "cordova-plugin-vibration": "^3.1.0",
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-plugin-x-socialsharing": "^5.4.1",
-    "cordova-sqlite-storage": "^2.5.0",
+    "cordova-sqlite-storage": "^2.5.1",
     "es6-promise-plugin": "^4.2.2",
     "iod": "^1.1.1",
     "ionic-angular": "^3.9.2",
@@ -112,7 +111,7 @@
   "devDependencies": {
     "@angular/cli": "^1.7.4",
     "@angular/router": "^5.2.11",
-    "@ionic/app-scripts": "^3.2.0",
+    "@ionic/app-scripts": "3.2.0",
     "@types/bcryptjs": "^2.4.2",
     "@types/jasmine": "^2.8.9",
     "@types/lodash": "^4.14.117",
@@ -157,9 +156,6 @@
       "cordova-plugin-device": {},
       "cordova-plugin-statusbar": {},
       "cordova-plugin-vibration": {},
-      "cordova-plugin-ionic-webview": {
-        "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
-      },
       "cordova-plugin-inappbrowser": {},
       "cordova-clipboard": {},
       "cordova-plugin-x-socialsharing": {},

--- a/src/modals/custom-network-create/custom-network-create.html
+++ b/src/modals/custom-network-create/custom-network-create.html
@@ -9,7 +9,7 @@
   </ion-navbar>
 </ion-header>
 
-<ion-content padding>
+<ion-content padding #content>
   <form #createForm="ngForm">
     <ion-grid fixed>
       <ion-row nowrap>
@@ -49,7 +49,7 @@
   </form>
 </ion-content>
 
-<ion-footer padding text-center no-shadow no-border>
+<ion-footer padding text-center no-shadow no-border [keyboard-attach]="content">
   <button ion-button
           class="button-continue"
           [disabled]="!createForm.valid || !getSeedServerUrl()"

--- a/src/modals/custom-network-create/custom-network-create.module.ts
+++ b/src/modals/custom-network-create/custom-network-create.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import {  IonicPageModule } from 'ionic-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { CustomNetworkCreateModal } from './custom-network-create';
+import { DirectivesModule } from '@directives/directives.module';
 
 @NgModule({
   declarations: [CustomNetworkCreateModal],
   imports: [
     IonicPageModule.forChild(CustomNetworkCreateModal),
+    DirectivesModule,
     TranslateModule
   ]
 })

--- a/src/modals/custom-network-edit/custom-network-edit.html
+++ b/src/modals/custom-network-edit/custom-network-edit.html
@@ -9,7 +9,7 @@
   </ion-navbar>
 </ion-header>
 
-<ion-content padding>
+<ion-content padding #content>
   <form #manageForm="ngForm">
     <ion-grid fixed>
       <ion-row nowrap>
@@ -138,7 +138,7 @@
   </form>
 </ion-content>
 
-<ion-footer no-border no-shadow>
+<ion-footer no-border no-shadow [keyboard-attach]="content">
   <ion-grid>
     <ion-row align-items-center>
       <ion-col>

--- a/src/modals/custom-network-edit/custom-network-edit.module.ts
+++ b/src/modals/custom-network-edit/custom-network-edit.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import {  IonicPageModule } from 'ionic-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { CustomNetworkEditModal } from './custom-network-edit';
+import { DirectivesModule } from '@directives/directives.module';
 
 @NgModule({
   declarations: [CustomNetworkEditModal],
   imports: [
     IonicPageModule.forChild(CustomNetworkEditModal),
+    DirectivesModule,
     TranslateModule
   ]
 })

--- a/src/modals/enter-second-passphrase/enter-second-passphrase.html
+++ b/src/modals/enter-second-passphrase/enter-second-passphrase.html
@@ -11,7 +11,7 @@
 
 </ion-header>
 
-<ion-content padding>
+<ion-content padding #content>
   <form #ngForm="ngForm">
     <ion-item>
       <ion-label stacked>{{ 'WALLETS_PAGE.ENTER_SECRET_PASSPHRASE' | translate }}</ion-label>
@@ -20,6 +20,6 @@
   </form>
 </ion-content>
 
-<ion-footer padding text-center no-shadow no-border>
+<ion-footer padding text-center no-shadow no-border [keyboard-attach]="content">
   <button ion-button class="button-continue" (click)="submit()" [disabled]="!ngForm.form.valid">{{ 'CONFIRM' | translate }}</button>
 </ion-footer>

--- a/src/modals/enter-second-passphrase/enter-second-passphrase.module.ts
+++ b/src/modals/enter-second-passphrase/enter-second-passphrase.module.ts
@@ -3,6 +3,7 @@ import { IonicPageModule } from 'ionic-angular';
 import { EnterSecondPassphraseModal } from './enter-second-passphrase';
 import { TranslateModule } from '@ngx-translate/core';
 import { ClosePopupComponentModule } from '@components/close-popup/close-popup.module';
+import { DirectivesModule } from '@directives/directives.module';
 
 @NgModule({
   declarations: [
@@ -10,6 +11,7 @@ import { ClosePopupComponentModule } from '@components/close-popup/close-popup.m
   ],
   imports: [
     IonicPageModule.forChild(EnterSecondPassphraseModal),
+    DirectivesModule,
     TranslateModule,
     ClosePopupComponentModule,
   ],

--- a/src/pages/contacts/contact-create/contact-create.html
+++ b/src/pages/contacts/contact-create/contact-create.html
@@ -23,7 +23,7 @@
   </form>
 </ion-content>
 
-<ion-footer padding no-shadow no-border>
+<ion-footer padding no-shadow no-border [keyboard-attach]="content">
   <button ion-button class="button-continue" [disabled]="!createContactForm.form.valid" (click)="submitForm()">{{ 'SAVE' | translate }}</button>
 </ion-footer>
 

--- a/src/pages/profiles/profile-create/profile-create.html
+++ b/src/pages/profiles/profile-create/profile-create.html
@@ -62,6 +62,6 @@
   </form>
 </ion-content>
 
-<ion-footer padding no-shadow no-border>
+<ion-footer padding no-shadow no-border [keyboard-attach]="content">
   <button ion-button class="button-continue" [disabled]="!createProfileForm.form.valid || !newProfile.networkId" (click)="submitForm()">{{ 'NEXT' | translate }}</button>
 </ion-footer>

--- a/src/pages/wallet/wallet-dashboard/modal/register-delegate/register-delegate.html
+++ b/src/pages/wallet/wallet-dashboard/modal/register-delegate/register-delegate.html
@@ -11,7 +11,7 @@
 
 </ion-header>
 
-<ion-content padding>
+<ion-content padding #content>
   <ion-grid>
     <ion-row>
       <ion-col align-self-center>
@@ -34,7 +34,7 @@
   </ion-grid>
 </ion-content>
 
-<ion-footer class="note-toolbar no-padding">
+<ion-footer class="note-toolbar no-padding" [keyboard-attach]="content">
   <ion-grid no-padding>
     <ion-row>
       <ion-col text-center no-padding>

--- a/src/pages/wallet/wallet-dashboard/modal/register-delegate/register-delegate.module.ts
+++ b/src/pages/wallet/wallet-dashboard/modal/register-delegate/register-delegate.module.ts
@@ -3,6 +3,7 @@ import { IonicPageModule } from 'ionic-angular';
 import { RegisterDelegatePage } from './register-delegate';
 
 import { TranslateModule } from '@ngx-translate/core';
+import { DirectivesModule } from '@directives/directives.module';
 import { PipesModule } from '@pipes/pipes.module';
 
 @NgModule({
@@ -11,6 +12,7 @@ import { PipesModule } from '@pipes/pipes.module';
   ],
   imports: [
     IonicPageModule.forChild(RegisterDelegatePage),
+    DirectivesModule,
     TranslateModule,
     PipesModule,
   ],

--- a/src/pages/wallet/wallet-dashboard/modal/register-second-passphrase/register-second-passphrase.html
+++ b/src/pages/wallet/wallet-dashboard/modal/register-second-passphrase/register-second-passphrase.html
@@ -11,7 +11,7 @@
 
 </ion-header>
 
-<ion-content padding>
+<ion-content padding #content>
   <ion-grid class="full-height" *ngIf="step == 1">
     <ion-row>
       <ion-col>
@@ -55,7 +55,7 @@
   </ion-grid>
 </ion-content>
 
-<ion-footer class="note-toolbar" hide-on-keyboard-open no-shadow no-border>
+<ion-footer class="note-toolbar" hide-on-keyboard-open no-shadow no-border [keyboard-attach]="content">
   <p *ngIf="step == 1">{{ 'WALLETS_PAGE.BACKUP_SECOND_PASSPHRASE_SECURELY_RETYPE_TEXT' | translate }}</p>
   <p *ngIf="step == 2">{{ 'WALLETS_PAGE.BACKUP_SECOND_PASSPHRASE' | translate }}</p>
 </ion-footer>

--- a/src/pages/wallet/wallet-dashboard/modal/register-second-passphrase/register-second-passphrase.module.ts
+++ b/src/pages/wallet/wallet-dashboard/modal/register-second-passphrase/register-second-passphrase.module.ts
@@ -4,6 +4,7 @@ import { RegisterSecondPassphrasePage } from './register-second-passphrase';
 
 import { TranslateModule } from '@ngx-translate/core';
 import { PipesModule } from '@pipes/pipes.module';
+import { DirectivesModule } from '@directives/directives.module';
 
 @NgModule({
   declarations: [
@@ -11,6 +12,7 @@ import { PipesModule } from '@pipes/pipes.module';
   ],
   imports: [
     IonicPageModule.forChild(RegisterSecondPassphrasePage),
+    DirectivesModule,
     TranslateModule,
     PipesModule,
   ],

--- a/src/pages/wallet/wallet-dashboard/modal/set-label/set-label.html
+++ b/src/pages/wallet/wallet-dashboard/modal/set-label/set-label.html
@@ -11,10 +11,10 @@
 
 </ion-header>
 
-<ion-content padding class="column-mode" no-bounce>
+<ion-content padding class="column-mode" no-bounce #content>
   <ion-grid class="full-height">
     <ion-row>
-      <ion-col text-center align-self-center>
+      <ion-col text-center>
         <form #labelForm="ngForm">
           <ion-item>
             <ion-label floating stacked>{{ 'WALLETS_PAGE.NEW_WALLET_NAME' | translate }}</ion-label>
@@ -23,10 +23,11 @@
         </form>
       </ion-col>
     </ion-row>
-    <ion-row>
-      <ion-col text-center align-self-end>
-        <button ion-button class="button-continue" color="primary" [disabled]="!labelForm.form.valid" (click)="submitForm()">{{ 'RENAME' | translate }}</button>
-      </ion-col>
-    </ion-row>
   </ion-grid>
 </ion-content>
+
+<ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">
+  <button ion-button class="button-continue" color="primary" [disabled]="!labelForm.form.valid" (click)="submitForm()">
+    {{ 'RENAME' | translate }}
+  </button>
+</ion-footer>

--- a/src/pages/wallet/wallet-dashboard/modal/set-label/set-label.module.ts
+++ b/src/pages/wallet/wallet-dashboard/modal/set-label/set-label.module.ts
@@ -3,6 +3,7 @@ import { IonicPageModule } from 'ionic-angular';
 import { SetLabelPage } from './set-label';
 
 import { TranslateModule } from '@ngx-translate/core';
+import { DirectivesModule } from '@directives/directives.module';
 
 @NgModule({
   declarations: [
@@ -10,6 +11,7 @@ import { TranslateModule } from '@ngx-translate/core';
   ],
   imports: [
     IonicPageModule.forChild(SetLabelPage),
+    DirectivesModule,
     TranslateModule,
   ],
 })

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -42,6 +42,6 @@
   <img class="hide-on-keyboard-open image">
 </ion-content>
 
-<ion-footer no-shadow no-border padding text-center>
+<ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">
   <button ion-button class="button-continue" [disabled]="!importWalletManual.form.valid" (click)="submitForm()">{{ 'IMPORT' | translate }}</button>
 </ion-footer>


### PR DESCRIPTION
## Proposed changes

This PR removes the `WKWebView` due to a vulnerability, and uses the native package `UIWebView`.

The keyboard plugin does not seem to work properly, so the directive for the footers has been added again.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)