### PR TITLE
fix: amounts with higher precision

### DIFF
--- a/src/components/amount/amount.ts
+++ b/src/components/amount/amount.ts
@@ -50,6 +50,7 @@ export class AmountComponent implements OnInit {
 
   public onInputToken() {
     const precision = this.marketCurrency.code === 'btc' ? 8 : 2;
+    this.amount = +(1.0 * this.amount).toFixed(8);
     this.amountEquivalent = +(this.amount * this.marketCurrency.price).toFixed(precision);
     this.hasChanged();
   }

--- a/src/components/amount/amount.ts
+++ b/src/components/amount/amount.ts
@@ -6,6 +6,8 @@ import { MarketDataProvider } from '@providers/market-data/market-data';
 import { SettingsDataProvider } from '@providers/settings-data/settings-data';
 import { Network } from 'ark-ts/model';
 import { Amount } from '@components/amount/amount.model';
+import * as constants from '@app/app.constants';
+import BigNumber from 'bignumber.js';
 
 @Component({
   selector: 'amount',
@@ -50,7 +52,7 @@ export class AmountComponent implements OnInit {
 
   public onInputToken() {
     const precision = this.marketCurrency.code === 'btc' ? 8 : 2;
-    this.amount = +(1.0 * this.amount).toFixed(8);
+    this.amount = Number((new BigNumber(this.amount.toString())).toFixed(constants.ARKTOSHI_DP));
     this.amountEquivalent = +(this.amount * this.marketCurrency.price).toFixed(precision);
     this.hasChanged();
   }


### PR DESCRIPTION
transaction_send page allowed users to enter amounts with precision of more than 8 decimal digits. These transactions were failing with status 400 after pressing the send button.
This PR fixes this bug.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Resolves #229 .

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
