### PR TITLE
Disable fiat amount when ARK=0

### DIFF
--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -21,7 +21,7 @@
         <p>{{ 'WALLETS_PAGE.TOTAL_BALANCE' | translate }}</p>
         <h2 class="amount">
           {{ currentNetwork?.symbol }} {{ totalBalance | unitsSatoshi }}
-          <span class="fiat" appMarketNetOnly>{{ fiatCurrency?.symbol }}{{ fiatBalance | marketNumber }}</span>
+          <span *ngIf="fiatBalance" class="fiat" appMarketNetOnly>{{ fiatCurrency?.symbol }}{{ fiatBalance | marketNumber }}</span>
         </h2>
       </ion-col>
     </ion-row>

--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -21,7 +21,7 @@
         <p>{{ 'WALLETS_PAGE.TOTAL_BALANCE' | translate }}</p>
         <h2 class="amount">
           {{ currentNetwork?.symbol }} {{ totalBalance | unitsSatoshi }}
-          <span *ngIf="fiatBalance" class="fiat" appMarketNetOnly>{{ fiatCurrency?.symbol }}{{ fiatBalance | marketNumber }}</span>
+          <span *ngIf="totalBalance" class="fiat" appMarketNetOnly>{{ fiatCurrency?.symbol }}{{ fiatBalance | marketNumber }}</span>
         </h2>
       </ion-col>
     </ion-row>


### PR DESCRIPTION

## Proposed changes

Earlier, on loading the profile, if ark balance was zero, it shew 'A 0 $'(didnt show amount in $). This was because on loading profile, fiatCurrency didn't initialize.
Since it is more appropriate not to show the fiat balance when user has 0ark and this also solves the above issue, I have disabled fiat amount when the ark is 0 by using *ngIf directive.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [ ] Lint and unit tests pass locally with my changes


## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
