### PR TITLE
fix: multiple imports of wallet

### DIFF
--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -43,5 +43,5 @@
 </ion-content>
 
 <ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">
-  <button ion-button class="button-continue" [disabled]="!importWalletManual.form.valid" (click)="submitForm()">{{ 'IMPORT' | translate }}</button>
+  <button ion-button class="button-continue" [disabled]="!importWalletManual.form.valid || submitted" (click)="submitForm()">{{ 'IMPORT' | translate }}</button>
 </ion-footer>

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
@@ -32,6 +32,7 @@ export class WalletManualImportPage extends BaseWalletImport  {
   public hidePassphrase = false;
   public passphraseHidden: string;
   public manualImportFormGroup: FormGroup;
+  public submitted = false;
 
   private wordlist;
   private suggestLanguageFound = false;
@@ -65,6 +66,7 @@ export class WalletManualImportPage extends BaseWalletImport  {
   }
 
   submitForm() {
+    this.submitted = true;
     this.import(this.useAddress ? this.addressOrPassphrase : null,
                 this.useAddress ? null : this.addressOrPassphrase,
                 !this.nonBIP39Passphrase);


### PR DESCRIPTION
On wallet-import-manual page if you press import multiple times you will notice wallet being imported multiple times.
Also, if you do this and aferwards try to remove the wallet, wallet won't be removed properly. It would reappear. It's probably related to #174 .

I was able to reproduce #174 most of the times after importing multiple times. Maybe @rdk1979 , imported multiple times. So most probably this would fix #174 
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
After import has been pressed, submitted is set to true and import button is hence disabled.
## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
