### PR TITLE
fix: save label only when dismissed with 'submit' role

### DIFF
--- a/src/pages/wallet/wallet-dashboard/modal/set-label/set-label.ts
+++ b/src/pages/wallet/wallet-dashboard/modal/set-label/set-label.ts
@@ -23,7 +23,7 @@ export class SetLabelPage {
   }
 
   submitForm() {
-    this.viewCtrl.dismiss(this.label);
+    this.viewCtrl.dismiss(this.label, 'submit');
   }
 
 }

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -262,10 +262,12 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
   presentLabelModal() {
     const modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label});
 
-    modal.onDidDismiss((label) => {
-      this.userDataProvider
+    modal.onDidDismiss((label, role) => {
+      if (role === 'submit') {
+        this.userDataProvider
           .setWalletLabel(this.wallet, label)
           .subscribe(null, error => this.toastProvider.error(error, 3000));
+      }
     });
 
     modal.present();


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Should fix #264, by adding a role to the modal dismiss event (which is called on close and submit) as the `onDidDismiss` handler is calling `this.userDataProvider.setWalletLabel()` even if the wallet is only closed.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes