### PR TITLE
fix: fetch dynamic fees from the new endpoint

### DIFF
--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -452,7 +452,7 @@ export class ArkApiProvider {
           fees: {
             minFee: Number(item.min),
             maxFee: Number(item.max),
-            avgFee: Number(item.max),
+            avgFee: Number(item.avg),
           }
         }));
 

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -20,6 +20,17 @@ import { ArkUtility } from '../../utils/ark-utility';
 import { Delegate } from 'ark-ts';
 import { StoredNetwork, FeeStatistic } from '@models/stored-network';
 
+interface NodeFees {
+  type: number;
+  min: number;
+  max: number;
+  avg: number;
+}
+
+interface NodeFeesResponse {
+  data: NodeFees[];
+}
+
 interface NodeConfigurationConstants {
   vendorFieldLength?: number;
 }
@@ -403,12 +414,12 @@ export class ArkApiProvider {
     });
 
     this.fetchFees().subscribe();
+    this.fetchFeeStatistics().subscribe();
     this.fetchNodeConfiguration().subscribe((response: NodeConfigurationResponse) => {
       const vendorFieldLength = response.data.constants.vendorFieldLength;
       if (vendorFieldLength) {
         this._network.vendorFieldLength = vendorFieldLength;
       }
-      this._network.feeStatistics = response.data.feeStatistics;
     });
   }
 
@@ -430,11 +441,32 @@ export class ArkApiProvider {
     }
 
     return Observable.create((observer) => {
-      this.fetchNodeConfiguration().subscribe((response: NodeConfigurationResponse) => {
+      this.httpClient.get(
+        `${this._network.getPeerAPIUrl()}/api/v2/node/fees?days=30`
+      ).subscribe((response: NodeFeesResponse) => {
         const data = response.data;
-        this._network.feeStatistics = data.feeStatistics;
-        observer.next(this._network.feeStatistics);
-      }, e => observer.error(e));
+        // Converts the new response to the old template
+        const feeStatistics: FeeStatistic[] = data.map(item => ({
+          type: Number(item.type),
+          fees: {
+            minFee: Number(item.min),
+            maxFee: Number(item.max),
+            avgFee: Number(item.max),
+          }
+        }));
+
+        this._network.feeStatistics = feeStatistics;
+        observer.next(feeStatistics);
+      }, () => {
+        this.fetchNodeConfiguration().subscribe(
+          (response: NodeConfigurationResponse) => {
+            const data = response.data;
+            this._network.feeStatistics = data.feeStatistics;
+            observer.next(this._network.feeStatistics);
+          },
+          e => observer.error(e)
+        );
+      });
     });
   }
 


### PR DESCRIPTION
## Proposed changes

The `feeStatistics` property has been removed from the endpoint `/node/configuration`, now the endpoint `/node/fees` must be used.

To reduce compatibility issues I just converted the new response to the old model.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)