### PR TITLE
refactor: use activeDelegates provided by network

### DIFF
--- a/src/pages/delegates/delegates.ts
+++ b/src/pages/delegates/delegates.ts
@@ -159,14 +159,14 @@ export class DelegatesPage implements OnDestroy {
     this.zone.runOutsideAngular(() => {
       this.arkApiProvider.delegates.subscribe((data) => this.zone.run(() => {
         this.delegates = data;
-        this.activeDelegates = this.delegates.slice(0, constants.NUM_ACTIVE_DELEGATES);
-        this.standByDelegates = this.delegates.slice(constants.NUM_ACTIVE_DELEGATES, this.delegates.length);
+        this.activeDelegates = this.delegates.slice(0, this.currentNetwork.activeDelegates);
+        this.standByDelegates = this.delegates.slice(this.currentNetwork.activeDelegates, this.delegates.length);
       }));
     });
 
     this.onUpdateDelegates();
     this.fetchCurrentVote();
-    this.arkApiProvider.fetchDelegates(constants.NUM_ACTIVE_DELEGATES * 2).subscribe();
+    this.arkApiProvider.fetchDelegates(this.currentNetwork.activeDelegates * 2).subscribe();
   }
 
   ngOnDestroy() {

--- a/src/pages/delegates/delegates.ts
+++ b/src/pages/delegates/delegates.ts
@@ -5,9 +5,10 @@ import { Subject } from 'rxjs/Subject';
 import { ArkApiProvider } from '@providers/ark-api/ark-api';
 import { UserDataProvider } from '@providers/user-data/user-data';
 import { ToastProvider } from '@providers/toast/toast';
-import { Delegate, Network, VoteType, TransactionVote } from 'ark-ts';
+import { Delegate, VoteType, TransactionVote } from 'ark-ts';
 
 import { Wallet, WalletKeys } from '@models/model';
+import { StoredNetwork } from '@models/stored-network';
 
 import * as constants from '@app/app.constants';
 import { PinCodeComponent } from '@components/pin-code/pin-code';
@@ -35,7 +36,7 @@ export class DelegatesPage implements OnDestroy {
   public preMinned: number = constants.BLOCKCHAIN_PREMINNED;
 
   public rankStatus = 'active';
-  public currentNetwork: Network;
+  public currentNetwork: StoredNetwork;
   public slides: string[] = [
     'active',
     'standBy',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

Use the number of active delegates provided by the network instead of the defined constant. Addition to #336.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
