### PR TITLE
fix: ensure numeric type for network version

### DIFF
--- a/src/app/modals/custom-network-edit/custom-network-edit.html
+++ b/src/app/modals/custom-network-edit/custom-network-edit.html
@@ -70,7 +70,8 @@
 							}}</ion-label
 						>
 						<ion-input
-							type="text"
+							type="number"
+							inputmode="numeric"
 							required
 							name="Version"
 							[(ngModel)]="network.version"

--- a/src/app/pages/transaction/transaction-send/transaction-send.ts
+++ b/src/app/pages/transaction/transaction-send/transaction-send.ts
@@ -274,6 +274,7 @@ export class TransactionSendPage implements OnInit, OnDestroy {
 			this.transaction.recipientAddress,
 			this.currentNetwork,
 		);
+
 		this.sendTransactionHTMLForm.form.controls.recipientAddress.setErrors({
 			incorrect: !isValid,
 		});


### PR DESCRIPTION
##  Summary

The edit network page is transforming the network version in string.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
