### PR TITLE
feat: BigInt support for browsers without native support

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,13 +2,11 @@ const webpack = require("webpack");
 
 const bigIntPolyfill = [];
 
-if (process.env.PLATFORM === "ios") {
-	bigIntPolyfill.push(
-		new webpack.DefinePlugin({
-			BigInt: "bigInt",
-		}),
-	);
-}
+bigIntPolyfill.push(
+	new webpack.ProvidePlugin({
+		BigInt: "big-integer",
+	}),
+);
 
 module.exports = {
 	module: {


### PR DESCRIPTION
## Summary

Implement BigInt support for browers without native support (Safari, ...). Since [big-integer](https://www.npmjs.com/package/big-integer) uses build in polyfill it is loaded by default. 

Related to issue: #[3784](https://github.com/ArkEcosystem/core/issues/3784)

## Checklist

- [ ] Tests (requires additional testing)
- [x] Ready to be merged
