### PR TITLE
refactor: use default peer on known networks

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.ark.wallet.mobile" version="1.8.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="io.ark.wallet.mobile" version="1.8.3" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Ark Mobile</name>
     <description>ARK</description>
     <author email="mobile@ark.io" href="http://ark.io/">Ark Ecosystem</author>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ark-mobile",
-	"version": "1.8.2",
+	"version": "1.8.3",
 	"author": "Ark Ecosystem <mobile@ark.io>",
 	"homepage": "https://github.com/ArkEcosystem/mobile-wallet#readme",
 	"scripts": {

--- a/src/app/modals/custom-network-create/custom-network-create.ts
+++ b/src/app/modals/custom-network-create/custom-network-create.ts
@@ -5,6 +5,7 @@ import { Network, Peer } from "ark-ts";
 import lodash from "lodash";
 import { finalize } from "rxjs/operators";
 
+import { LoggerService } from "@/services/logger/logger.service";
 import { ToastProvider } from "@/services/toast/toast";
 import ArkClient from "@/utils/ark-client";
 
@@ -23,6 +24,7 @@ export class CustomNetworkCreateModal {
 		private toastProvider: ToastProvider,
 		private loadingCtrl: LoadingController,
 		private httpClient: HttpClient,
+		private loggerService: LoggerService,
 	) {}
 
 	public dismiss(network?: Network): void {
@@ -35,7 +37,7 @@ export class CustomNetworkCreateModal {
 
 		const seedServerUrl = this.getSeedServerUrl();
 
-		new ArkClient(this.seedServer, this.httpClient)
+		new ArkClient(this.seedServer, this.httpClient, this.loggerService)
 			.getNodeConfiguration()
 			.pipe(finalize(() => loading.dismiss()))
 			.subscribe(
@@ -61,6 +63,8 @@ export class CustomNetworkCreateModal {
 					this.network.activePeer = new Peer();
 					this.network.activePeer.ip = seedServerUrl.hostname;
 					this.network.activePeer.port = apiConfig;
+					// @ts-ignore
+					this.network.activePeer.protocol = seedServerUrl.protocol;
 
 					this.network.isV2 = true;
 					this.dismiss(this.network);

--- a/src/app/modals/custom-network-create/custom-network-create.ts
+++ b/src/app/modals/custom-network-create/custom-network-create.ts
@@ -63,6 +63,10 @@ export class CustomNetworkCreateModal {
 					this.network.activePeer = new Peer();
 					this.network.activePeer.ip = seedServerUrl.hostname;
 					this.network.activePeer.port = apiConfig;
+
+					if (seedServerUrl.protocol === "https:") {
+						this.network.activePeer.port = 443;
+					}
 					// @ts-ignore
 					this.network.activePeer.protocol = seedServerUrl.protocol;
 

--- a/src/app/modals/custom-network-edit/custom-network-edit.html
+++ b/src/app/modals/custom-network-edit/custom-network-edit.html
@@ -121,8 +121,7 @@
 							type="text"
 							required
 							name="apiPort"
-							[(ngModel)]="apiPort"
-							(ionChange)="updateApiPort()"
+							[(ngModel)]="network.activePeer.port"
 						>
 						</ion-input>
 					</ion-item>

--- a/src/app/modals/custom-network-edit/custom-network-edit.ts
+++ b/src/app/modals/custom-network-edit/custom-network-edit.ts
@@ -22,7 +22,6 @@ export interface EditNetworkResult {
 })
 export class CustomNetworkEditModal {
 	public network: StoredNetwork;
-	public apiPort: number;
 	public networkId: string;
 	public isDefault: boolean;
 
@@ -41,17 +40,10 @@ export class CustomNetworkEditModal {
 		this.networkId = this.navParams.get("id");
 
 		this.isDefault = defaultNetworksNames.includes(this.network.name);
-		this.apiPort = this.network.isV2
-			? this.network.apiPort
-			: this.network.activePeer.port;
 	}
 
 	dismiss(result?: EditNetworkResult) {
 		this.modalCtrl.dismiss(result);
-	}
-
-	public updateApiPort() {
-		this.network.apiPort = this.apiPort;
 	}
 
 	public save(): void {

--- a/src/app/modals/custom-network-edit/custom-network-edit.ts
+++ b/src/app/modals/custom-network-edit/custom-network-edit.ts
@@ -23,7 +23,6 @@ export interface EditNetworkResult {
 export class CustomNetworkEditModal {
 	public network: StoredNetwork;
 	public apiPort: number;
-	public p2pPort: number;
 	public networkId: string;
 	public isDefault: boolean;
 
@@ -45,9 +44,6 @@ export class CustomNetworkEditModal {
 		this.apiPort = this.network.isV2
 			? this.network.apiPort
 			: this.network.activePeer.port;
-		this.p2pPort = this.network.isV2
-			? this.network.p2pPort
-			: this.network.activePeer.port;
 	}
 
 	dismiss(result?: EditNetworkResult) {
@@ -56,13 +52,6 @@ export class CustomNetworkEditModal {
 
 	public updateApiPort() {
 		this.network.apiPort = this.apiPort;
-	}
-
-	public updateP2PPort() {
-		if (this.network.isV2) {
-			this.network.p2pPort = this.p2pPort;
-		}
-		this.network.activePeer.port = this.p2pPort;
 	}
 
 	public save(): void {

--- a/src/app/models/node.ts
+++ b/src/app/models/node.ts
@@ -13,6 +13,9 @@ export interface IFees {
 }
 
 export interface INodeConfiguration {
+	core: {
+		version: string;
+	};
 	nethash: string;
 	slip44: number;
 	wif: number;

--- a/src/app/models/stored-network.ts
+++ b/src/app/models/stored-network.ts
@@ -1,4 +1,5 @@
 import { Network } from "ark-ts";
+import URL from "url";
 
 import { PeerApiResponse } from "@/utils/ark-client";
 
@@ -28,6 +29,10 @@ export class StoredNetwork extends Network {
 	getPeerAPIUrl() {
 		// @ts-ignore
 		const protocol = this.activePeer.protocol || "http";
-		return `${protocol}://${this.activePeer.ip}:${this.activePeer.port}`;
+		return URL.format({
+			protocol,
+			hostname: this.activePeer.ip,
+			port: this.activePeer.port,
+		});
 	}
 }

--- a/src/app/models/stored-network.ts
+++ b/src/app/models/stored-network.ts
@@ -24,4 +24,10 @@ export class StoredNetwork extends Network {
 	public activeDelegates: number;
 	public vendorFieldLength?: number;
 	public aip11: boolean;
+
+	getPeerAPIUrl() {
+		// @ts-ignore
+		const protocol = this.activePeer.protocol || "http";
+		return `${protocol}://${this.activePeer.ip}:${this.activePeer.port}`;
+	}
 }

--- a/src/app/pages/network/network-status/network-status.html
+++ b/src/app/pages/network/network-status/network-status.html
@@ -17,7 +17,9 @@
 							<div class="item-title">
 								{{ 'NETWORKS_PAGE.PEER' | translate }}
 							</div>
-							<div class="item-content">{{ getPeerUrl() }}</div>
+							<div class="item-content">
+								{{ currentNetwork.getPeerAPIUrl() }}
+							</div>
 						</ion-label>
 					</ion-item>
 

--- a/src/app/pages/network/network-status/network-status.ts
+++ b/src/app/pages/network/network-status/network-status.ts
@@ -83,12 +83,12 @@ export class NetworkStatusPage implements OnInit, OnDestroy {
 
 	private refreshData() {
 		this.arkApiProvider.client
-			.getPeerConfig(this.currentPeer.ip, this.currentNetwork.p2pPort)
+			.getNodeConfiguration(this.getPeerUrl())
 			.pipe(takeUntil(this.unsubscriber$))
 			.subscribe((response) => {
 				if (response) {
 					this.zone.run(() => {
-						this.currentPeer.version = response.data.version;
+						this.currentPeer.version = response.core.version;
 					});
 				}
 			});

--- a/src/app/pages/network/network-status/network-status.ts
+++ b/src/app/pages/network/network-status/network-status.ts
@@ -33,10 +33,6 @@ export class NetworkStatusPage implements OnInit, OnDestroy {
 		this.currentPeer = this.currentNetwork.activePeer;
 	}
 
-	getPeerUrl() {
-		return `http://${this.currentPeer.ip}:${this.currentPeer.port}`;
-	}
-
 	changePeer() {
 		this.translateService
 			.get("NETWORKS_PAGE.LOOKING_GOOD_PEER")
@@ -83,7 +79,7 @@ export class NetworkStatusPage implements OnInit, OnDestroy {
 
 	private refreshData() {
 		this.arkApiProvider.client
-			.getNodeConfiguration(this.getPeerUrl())
+			.getNodeConfiguration(this.currentNetwork.getPeerAPIUrl())
 			.pipe(takeUntil(this.unsubscriber$))
 			.subscribe((response) => {
 				if (response) {
@@ -94,7 +90,7 @@ export class NetworkStatusPage implements OnInit, OnDestroy {
 			});
 
 		this.arkApiProvider.client
-			.getPeerSyncing(this.getPeerUrl())
+			.getPeerSyncing(this.currentNetwork.getPeerAPIUrl())
 			.pipe(takeUntil(this.unsubscriber$))
 			.subscribe((response) => {
 				if (response) {

--- a/src/app/services/ark-api/ark-api.ts
+++ b/src/app/services/ark-api/ark-api.ts
@@ -30,6 +30,7 @@ import { SafeBigNumber as BigNumber } from "@/utils/bignumber";
 
 import ArkClient, { WalletResponse } from "../../utils/ark-client";
 import { ArkUtility } from "../../utils/ark-utility";
+import { LoggerService } from "../logger/logger.service";
 
 interface NodeFees {
 	type: number;
@@ -71,6 +72,7 @@ export class ArkApiProvider {
 		private userDataService: UserDataService,
 		private storageProvider: StorageProvider,
 		private toastProvider: ToastProvider,
+		private loggerService: LoggerService,
 	) {
 		this.loadData();
 
@@ -142,6 +144,7 @@ export class ArkApiProvider {
 		this._client = new ArkClient(
 			this.network.getPeerAPIUrl(),
 			this.httpClient,
+			this.loggerService,
 		);
 		this._peerDiscovery = new PeerDiscovery(this.httpClient);
 
@@ -169,11 +172,13 @@ export class ArkApiProvider {
 			const defaultNetworks = {
 				mainnet: {
 					ip: "wallets.ark.io",
-					port: "80",
+					port: "443",
+					protocol: "https",
 				},
 				devnet: {
 					ip: "dwallets.ark.io",
-					port: "80",
+					port: "443",
+					protocol: "https",
 				},
 			};
 
@@ -523,6 +528,7 @@ export class ArkApiProvider {
 		this._client = new ArkClient(
 			this._network.getPeerAPIUrl(),
 			this.httpClient,
+			this.loggerService,
 		);
 
 		this.fetchDelegates(this._network.activeDelegates * 2).subscribe(

--- a/src/app/services/ark-api/ark-api.ts
+++ b/src/app/services/ark-api/ark-api.ts
@@ -150,7 +150,7 @@ export class ArkApiProvider {
 		// Fallback if the fetchNodeConfiguration fail
 		this._network.activeDelegates = constants.NUM_ACTIVE_DELEGATES;
 
-		this.connectToRandomPeer()
+		this.connectToPeer()
 			.pipe(
 				catchError((e) => {
 					console.error(e);
@@ -162,6 +162,35 @@ export class ArkApiProvider {
 		this.userDataService.onUpdateNetwork$.next(this._network);
 
 		this.fetchFees().subscribe();
+	}
+
+	public connectToPeer(): Observable<void> {
+		return new Observable((observer) => {
+			const defaultNetworks = {
+				mainnet: {
+					ip: "wallets.ark.io",
+					port: "80",
+				},
+				devnet: {
+					ip: "dwallets.ark.io",
+					port: "80",
+				},
+			};
+
+			const isKnowNetwork = lodash.includes(
+				Object.keys(defaultNetworks),
+				this._network.name,
+			);
+
+			if (isKnowNetwork) {
+				this.updateNetwork(defaultNetworks[this._network.name]);
+				observer.next();
+				observer.complete();
+				return;
+			}
+
+			this.connectToRandomPeer().subscribe(observer);
+		});
 	}
 
 	public connectToRandomPeer(): Observable<void> {

--- a/src/app/utils/ark-client.ts
+++ b/src/app/utils/ark-client.ts
@@ -8,11 +8,9 @@ import {
 	LoaderStatusSync,
 	Peer,
 	PeerResponse,
-	PeerVersion2ConfigResponse,
 	TransactionPostResponse,
 	TransactionResponse,
 } from "ark-ts";
-import lodash from "lodash";
 import { Observable, of } from "rxjs";
 import { timeout } from "rxjs/operators";
 
@@ -225,66 +223,6 @@ export default class ApiClient {
 				},
 				(error) => observer.error(error),
 			);
-		});
-	}
-
-	getPeerConfig(
-		ip: string,
-		port: number,
-		protocol: "http" | "https" = "http",
-	): Observable<PeerVersion2ConfigResponse> {
-		return new Observable((observer) => {
-			this.httpClient
-				.get(`${protocol}://${ip}:4040/config`)
-				.pipe(timeout(2000))
-				.subscribe(
-					(response: any) => {
-						observer.next(response);
-						observer.complete();
-					},
-					() => {
-						this.httpClient
-							.get(`${protocol}://${ip}:${port}/config`)
-							.pipe(timeout(2000))
-							.subscribe(
-								(response: any) => {
-									observer.next(response);
-									observer.complete();
-								},
-								() => {
-									this.getNodeConfiguration(
-										`${protocol}://${ip}:${port}`,
-									).subscribe(
-										(response) => {
-											const apiPort = lodash.find(
-												response.ports,
-												(_, key) =>
-													key
-														.split("/")
-														.reverse()[0] ===
-													"core-wallet-api",
-											);
-											const isApiEnabled =
-												apiPort && Number(apiPort) > 1;
-											if (isApiEnabled) {
-												this.getPeerConfig(
-													ip,
-													apiPort,
-													protocol,
-												).subscribe(
-													(r) => observer.next(r),
-													(e) => observer.error(e),
-												);
-											} else {
-												observer.error();
-											}
-										},
-										(error) => observer.error(error),
-									);
-								},
-							);
-					},
-				);
 		});
 	}
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -301,7 +301,7 @@
 
 		"UNDEFINED_REGISTRATION": "Registration (Undefined)",
 		"UNDEFINED_RESIGNATION": "Resignation (Undefined)",
-		"UNDEFINED_UPDAE": "Update (Undefined)",
+		"UNDEFINED_UPDATE": "Update (Undefined)",
 
 		"UNDEFINED": "Undefined"
 	},


### PR DESCRIPTION
## Summary

Connect in a default peer for mainnet and devnet, otherwise it looks for a random peer. User will still be able to change the peer in session.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
