### PR TITLE
fix: use recipient address to sign transaction

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.ark.wallet.mobile" version="1.8.4" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="io.ark.wallet.mobile" version="1.8.5" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Ark Mobile</name>
     <description>ARK</description>
     <author email="mobile@ark.io" href="http://ark.io/">Ark Ecosystem</author>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ark-mobile",
-	"version": "1.8.4",
+	"version": "1.8.5",
 	"author": "Ark Ecosystem <mobile@ark.io>",
 	"homepage": "https://github.com/ArkEcosystem/mobile-wallet#readme",
 	"scripts": {

--- a/src/app/models/transaction.ts
+++ b/src/app/models/transaction.ts
@@ -54,7 +54,7 @@ export class Transaction extends TransactionModel {
 			}
 		}
 		this.senderId = input.sender;
-		this.recipientId = input.recipient;
+		this.recipientId = input.recipient || input.recipientId;
 		this.date = new Date(this.timestamp * 1000);
 		this.amount = new BigNumber(input.amount).toNumber();
 		this.fee = new BigNumber(input.fee).toNumber();


### PR DESCRIPTION
## Summary

Use the recipient field to sign transactions.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
